### PR TITLE
BloonsPy 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,25 @@
 # Changelog
 
+## [0.4.0](https://pypi.org/project/bloonspy/0.4.0) - 2023-07-XX
+
+### Added
++ Custom exception for when the server is under maintenance
++ `Team.name` is parsed to appear exactly like it is in-game.
+  + `(disbanded)` won't appear in a team's name. Instead, check for `Team.status == TeamStatus.DISBANDED`
+  + The team code won't appear appended to the name, if it was there to begin with
+  + `Team.name` is always uppercase
+  + The unfiltered team name is still accessible via `Team.full_name`
++ Added `score_parts` to `BossPlayer`, `BossTeam`, `RacePlayer`
+
+### Changed
++ `score` attribute in `BossPlayer`, `BossTeam`, and `RacePlayer` returns a `Score` object
+
 ## [0.3.0](https://pypi.org/project/bloonspy/0.3.0) - 2023-04-27
 
 ### Added
 + Package now handles rate limiting
-+ `Challenge.restarts`
-+ `Odyssey.description`, `OdysseyEvent.description`
++ Added `Challenge.restarts`
++ Added `Odyssey.description`, `OdysseyEvent.description`
 + `Event` and `Loadable` support the `==` operator
 
 ### Changed
@@ -32,7 +46,7 @@
 + Object returned from `Gamemode.from_string` should have the correct `mode`
 + `BossPlayer.score` and `RacePlayer.score` now correctly store microseconds
 
-## [0.1.0](https://pypi.org/project/bloonspy/0.1.1/) - 2023-03-28
+## [0.1.1](https://pypi.org/project/bloonspy/0.1.1/) - 2023-03-28
 
 ### Changed
 + `start_from_page` defaults to `1` on all methods that support it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [0.4.0](https://pypi.org/project/bloonspy/0.4.0) - 2023-07-XX
+## [0.4.0](https://pypi.org/project/bloonspy/0.4.0) - 2023-08-15
 
 ### Added
 + Custom exception for when the server is under maintenance

--- a/bloonspy/__init__.py
+++ b/bloonspy/__init__.py
@@ -2,5 +2,5 @@ from .Client import *
 from .model import btd6
 from .utils import Infinity
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"
 __author__ = "TheSartorsss"

--- a/bloonspy/exceptions.py
+++ b/bloonspy/exceptions.py
@@ -1,11 +1,21 @@
 
 
 class BloonsException(Exception):
-    """Superclass for all Bloons exceptions"""
+    """Superclass for all Bloons exceptions. Can be used as a catch-all."""
     pass
 
 
 class NotFound(BloonsException):
     """The requested resource or event doesn't exist or has expired."""
+    pass
+
+
+class UnderMaintenance(BloonsException):
+    """The Ninja Kiwi server is under maintenance."""
+    pass
+
+
+class BadTeamSize(BloonsException):
+    """You specified a bad team size."""
     pass
 

--- a/bloonspy/model/btd6/Boss.py
+++ b/bloonspy/model/btd6/Boss.py
@@ -2,6 +2,7 @@ from enum import Enum
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta
 from typing import List, Dict, Any, Tuple, Union
+from ...exceptions import BadTeamSize
 from ...utils.decorators import fetch_property, exception_handler
 from ...utils.api import get, get_lb_page
 from ..Loadable import Loadable
@@ -151,10 +152,10 @@ class Boss(Challenge):
         :rtype: Union[List[:class:`~bloonspy.model.btd6.BossPlayer`], List[:class:`~bloonspy.model.btd6.BossPlayerTeam`]]
 
         :raise ~bloonspy.exceptions.NotFound: If the boss doesn't exist or is expired.
-        :raise ValueError: If `team_size` is less than 1 or more than 4.
+        :raise BadTeamSize: If `team_size` is less than 1 or more than 4.
         """
         if team_size not in range(1, 5):
-            raise ValueError("team_size must be between 1 and 4")
+            raise BadTeamSize("team_size must be between 1 and 4")
 
         futures = []
         with ThreadPoolExecutor(max_workers=10) as executor:

--- a/bloonspy/model/btd6/ContestedTerritory.py
+++ b/bloonspy/model/btd6/ContestedTerritory.py
@@ -29,7 +29,8 @@ class CtPlayer(User):
 
 
 class CtTeam(Team):
-    """A team who participated in Contested Territory and is on the leaderboards."""
+    """A team who participated in Contested Territory and is on the leaderboards.
+    Inherits from :class:`~bloonspy.model.btd6.Team`."""
     def __init__(self, team_id: str, name: str, score: int, **kwargs):
         super().__init__(team_id, **kwargs)
         self._name = name

--- a/bloonspy/model/btd6/Score.py
+++ b/bloonspy/model/btd6/Score.py
@@ -1,0 +1,69 @@
+from dataclasses import dataclass
+from datetime import timedelta
+from enum import Enum
+from typing import Dict, Any
+
+
+class ScoreType(Enum):
+    GAME_TIME = "Game Time"
+    CASH_SPENT = "Cash Spent"
+    TIERS = "Tiers"
+    TIME_AFTER_EVENT_START = "Time After Event Start"
+
+    @staticmethod
+    def from_string(value: str) -> "ScoreType":
+        score_type_switch = {
+            "Game Time": ScoreType.GAME_TIME,
+            "Cash Spent": ScoreType.CASH_SPENT,
+            "Tiers": ScoreType.TIERS,
+            "Time after event start": ScoreType.TIME_AFTER_EVENT_START,
+        }
+        return score_type_switch[value] if value in score_type_switch else None
+
+
+@dataclass
+class Score:
+    """An event score."""
+    type: ScoreType  #: What the score represents.
+    value: int | timedelta  #: The actual score value.
+
+    @staticmethod
+    def from_json(data: Dict[str, Any]) -> "Score":
+        value = data["score"]
+        if data["type"] == "time":
+            value = timedelta(microseconds=data["score"]*1000)
+        return Score(
+            ScoreType.from_string(data["name"]), value
+        )
+
+    def __str__(self) -> str:
+        if self.type == ScoreType.CASH_SPENT:
+            return f"${self.value:,}"
+        elif self.type == ScoreType.TIERS:
+            return f"{self.value:,}"
+        return str(self.value)
+
+    def __eq__(self, other) -> bool:
+        return isinstance(other, Score) and \
+            other.type == self.type and \
+            other.value == self.value
+
+    def __gt__(self, other) -> bool:
+        return isinstance(other, Score) and \
+            other.type == self.type and \
+            self.type > other.type
+
+    def __ge__(self, other) -> bool:
+        return isinstance(other, Score) and \
+            other.type == self.type and \
+            self.type >= other.type
+
+    def __lt__(self, other) -> bool:
+        return isinstance(other, Score) and \
+            other.type == self.type and \
+            self.type < other.type
+
+    def __le__(self, other) -> bool:
+        return isinstance(other, Score) and \
+            other.type == self.type and \
+            self.type <= other.type

--- a/bloonspy/model/btd6/Team.py
+++ b/bloonspy/model/btd6/Team.py
@@ -39,6 +39,14 @@ class Team(Loadable):
         copy_keys = ["name", "numMembers"]
         for key in copy_keys:
             self._data[key] = raw_resource[key]
+
+        self._data["full_name"] = self._data["name"]
+        if " (disbanded)" in self._data["name"]:
+            self._data["name"] = self._data["name"].replace(" (disbanded)", "")
+        if "-" in self._data["name"]:
+            self._data["name"] = self._data["name"].split("-")[0]
+        self._data["name"] = self._data["name"].upper()
+
         assets = [
             ("banner", "bannerURL"), ("icon", "iconURL"), ("frame", "frameURL"),
         ]
@@ -51,8 +59,18 @@ class Team(Loadable):
 
     @property
     @fetch_property(Loadable.load_resource)
+    def full_name(self) -> str:
+        """
+        The complete name of the team.
+        It may not be exactly what you see in game, in some cases it has
+        the team code appended at the end, among other things.
+        """
+        return self._data["full_name"]
+
+    @property
+    @fetch_property(Loadable.load_resource)
     def name(self) -> str:
-        """The name of the team."""
+        """The name of the team, as seen in-game."""
         return self._data["name"]
 
     @property

--- a/bloonspy/model/btd6/__init__.py
+++ b/bloonspy/model/btd6/__init__.py
@@ -10,3 +10,4 @@ from .Restriction import *
 from .Team import *
 from .Tower import *
 from .User import *
+from .Score import *

--- a/docs/source/pages/api.rst
+++ b/docs/source/pages/api.rst
@@ -208,6 +208,12 @@ Infinity
 .. autoclass:: bloonspy.Infinity()
    :members:
 
+Infinity
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: bloonspy.model.btd6.Score()
+   :members:
+
 Enums
 ------------
 
@@ -259,6 +265,12 @@ Tower
 .. autoenum:: bloonspy.model.btd6.Tower
    :members:
 
+Tower
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoenum:: bloonspy.model.btd6.ScoreParts
+   :members:
+
 Exceptions
 ---------------------------------
 
@@ -272,4 +284,16 @@ NotFound
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. autoclass:: bloonspy.exceptions.NotFound
+   :members:
+
+UnderMaintenance
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: bloonspy.exceptions.UnderMaintenance
+   :members:
+
+BadTeamSize
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: bloonspy.exceptions.BadTeamSize
    :members:

--- a/tests/integration/test_boss_leaderboard.py
+++ b/tests/integration/test_boss_leaderboard.py
@@ -1,6 +1,5 @@
 import unittest
 from datetime import datetime, timedelta
-import requests
 import random
 from bloonspy import btd6, Client
 
@@ -21,7 +20,7 @@ class TestBossLeaderboard(unittest.TestCase):
                               msg=f"Assert if result is BossPlayer")
 
         check_instance = [
-            ("name", str), ("score", timedelta), ("submission_time", datetime),
+            ("name", str), ("score", btd6.Score), ("submission_time", datetime),
             ("achievements", int), ("boss_normal_medals", btd6.EventMedals)
         ]
         for attr_name, attr_type in check_instance:
@@ -37,10 +36,10 @@ class TestBossLeaderboard(unittest.TestCase):
         boss_leaderboard_coop = boss.standard().leaderboard(pages=3, team_size=3)
 
         check_instance = [
-            ("score", timedelta), ("submission_time", datetime), ("is_fully_loaded", bool)
+            ("score", btd6.Score), ("submission_time", datetime), ("is_fully_loaded", bool)
         ]
         for i in range(len(boss_leaderboard_coop)):
-            team = boss_leaderboard_coop[i]
+            team: btd6.BossPlayerTeam = boss_leaderboard_coop[i]
             self.assertLessEqual(len(team.players), 3,
                                  msg="Assert if BossPlayerTeam has the correct number of players.")
             for attr_name, attr_type in check_instance:

--- a/tests/integration/test_race_leaderboard.py
+++ b/tests/integration/test_race_leaderboard.py
@@ -1,6 +1,5 @@
 import unittest
-from datetime import datetime, timedelta
-import requests
+from datetime import datetime
 import random
 from bloonspy import btd6, Client
 
@@ -21,7 +20,7 @@ class TestRaceLeaderboard(unittest.TestCase):
                               msg=f"Assert if result is RacePlayer")
 
         check_instance = [
-            ("name", str), ("score", timedelta), ("submission_time", datetime),
+            ("name", str), ("score", btd6.Score), ("submission_time", datetime),
             ("achievements", int), ("boss_normal_medals", btd6.EventMedals)
         ]
         for attr_name, attr_type in check_instance:

--- a/tests/unit/test_team.py
+++ b/tests/unit/test_team.py
@@ -1,6 +1,4 @@
 import unittest
-from datetime import datetime
-import bloonspy
 from bloonspy import btd6
 
 
@@ -44,6 +42,16 @@ class TestTeam(unittest.TestCase):
         except btd6.NotFound:
             correct_exception = True
         self.assertTrue(correct_exception, msg="Wrong team IDs should raise bloonspy.exceptions.NotFound")
+
+    def test_team_disbanded(self) -> None:
+        """
+        Test that disbanded teams have their name properly formatted and their status set to TeamStatus.DISBANDED.
+        """
+        team_id = "9fbd42d9db90aaf34a168e4c0e73b4249d0d1cb99b46db3f"
+        team = btd6.Team(team_id)
+        self.assertEqual(team.name, "HIDDEN AGENDA")
+        self.assertEqual(team.full_name, "HIDDEN AGENDA (disbanded)")
+        self.assertEqual(team.status, btd6.TeamStatus.DISBANDED)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION

### Added
+ Custom exception for when the server is under maintenance
+ `Team.name` is parsed to appear exactly like it is in-game.
  + `(disbanded)` won't appear in a team's name. Instead, check for `Team.status == TeamStatus.DISBANDED`
  + The team code won't appear appended to the name, if it was there to begin with
  + `Team.name` is always uppercase
  + The unfiltered team name is still accessible via `Team.full_name`
+ Added `score_parts` to `BossPlayer`, `BossTeam`, `RacePlayer`

### Changed
+ `score` attribute in `BossPlayer`, `BossTeam`, and `RacePlayer` returns a `Score` object
