### PR TITLE
feat: Fixed tests, deprecated old CT names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.8.0](https://pypi.org/project/bloonspy/0.8.0) - 2023-11-18
+
+### Changed
+- `CTGlobalMedals` renamed to `CtGlobalMedals`
+- `CTLocalMedals` renamed to `CtLocalMedals`
+- `ScoreType.CASH_SPENT` renamed to `ScoreType.LEAST_CASH`
+- `ScoreType.TIERS` renamed to `ScoreType.LEAST_TIERS`
+- `BossEvent.score_type` should be properly fetched when trying to access it through a non-eager instance.
+- `bloonspy.model.btd6` exports fixed to not import everything
+- Added `Achievement.WORLD_LEAGUE_TRAINING`
+
 ## [0.7.0](https://pypi.org/project/bloonspy/0.7.0) - 2023-10-13
 
 ### Added

--- a/bloonspy/__init__.py
+++ b/bloonspy/__init__.py
@@ -2,5 +2,5 @@ from .Client import *
 from .model import btd6
 from .utils import Infinity
 
-__version__ = "0.7.0"
+__version__ = "0.8.0"
 __author__ = "TheSartorsss"

--- a/bloonspy/model/__init__.py
+++ b/bloonspy/model/__init__.py
@@ -2,3 +2,4 @@ from .Loadable import Loadable
 from .Event import Event
 from .GameVersion import GameVersion
 from .Asset import Asset
+from .btd6 import *

--- a/bloonspy/model/btd6/Boss.py
+++ b/bloonspy/model/btd6/Boss.py
@@ -250,7 +250,7 @@ class BossEvent(Event):
     """A boss event. Inherits from :class:`~bloonspy.model.Event`."""
     event_endpoint = "/btd6/bosses"
     event_dict_keys = ["name", "bossType", "bossTypeURL", "start", "end", "totalScores_standard",
-                       "totalScores_elite"]
+                       "totalScores_elite", "scoringType"]
     event_name: str = "Boss"
 
     def _parse_event(self, data: Dict[str, Any]) -> None:
@@ -262,30 +262,31 @@ class BossEvent(Event):
         super()._parse_event(data)
 
     @property
-    @fetch_property(Event.load_event, should_load=Event._should_load_property)
+    @fetch_property(Event.load_event, should_load=Event._should_load_property("boss_bloon"))
     def boss_bloon(self) -> BossBloon:
         """The boss bloon in this event."""
         return self._data["boss_bloon"]
 
     @property
-    @fetch_property(Event.load_event, should_load=Event._should_load_property)
+    @fetch_property(Event.load_event, should_load=Event._should_load_property("boss_banner"))
     def boss_banner(self) -> str:
         """The URL to the banner used to advertise the event."""
         return self._data["boss_banner"]
 
     @property
-    @fetch_property(Event.load_event, should_load=Event._should_load_property)
+    @fetch_property(Event.load_event, should_load=Event._should_load_property("total_scores_standard"))
     def total_scores_standard(self) -> int:
         """Total scores submitted in the standard boss."""
         return self._data["total_scores_standard"]
 
     @property
-    @fetch_property(Event.load_event, should_load=Event._should_load_property)
+    @fetch_property(Event.load_event, should_load=Event._should_load_property("total_scores_elite"))
     def total_scores_elite(self) -> int:
         """Total scores submitted in the elite boss."""
         return self._data["total_scores_elite"]
 
     @property
+    @fetch_property(Event.load_event, should_load=Event._should_load_property("scoring_type"))
     def scoring_type(self) -> ScoreType:
         """
         *New in 0.6.2*

--- a/bloonspy/model/btd6/Medals.py
+++ b/bloonspy/model/btd6/Medals.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass, field
+import warnings
 
 
 @dataclass(kw_only=True)
@@ -16,7 +17,7 @@ class EventMedals:
 
 
 @dataclass(kw_only=True)
-class CTLocalMedals:
+class CtLocalMedals:
     """Medal set for Contested Territory (local leaderboard)."""
     first: int = field(default=0)  #: Number of first place finishes.
     second: int = field(default=0)  #: Number of second place finishes.
@@ -28,7 +29,7 @@ class CTLocalMedals:
 
 
 @dataclass(kw_only=True)
-class CTGlobalMedals:
+class CtGlobalMedals:
     """Medal set for Contested Territory (global leaderboard)."""
     top_25: int = field(default=0)  #: Number of Top 25 finishes.
     top_100: int = field(default=0)  #: Number of Top 100 finishes.
@@ -57,3 +58,14 @@ class MapMedals:
     impoppable: int = field(default=0)  #: Number of medals for Hard - Impoppable.
     chimps_red: int = field(default=0)  #: Number of medals for Hard - CHIMPS (red).
     chimps_black: int = field(default=0)  #: Number of medals for Hard - CHIMPS (black).
+
+
+def CTGlobalMedals(*args, **kwargs) -> CtGlobalMedals:
+    warnings.warn("CTGlobalMedals is deprecated, please use CtGlobalMedals instead.")
+    return CtGlobalMedals(*args, **kwargs)
+
+
+def CTLocalMedals(*args, **kwargs) -> CtLocalMedals:
+    warnings.warn("CTLocalMedals is deprecated, please use CtLocalMedals instead.")
+    return CtLocalMedals(*args, **kwargs)
+

--- a/bloonspy/model/btd6/Progress.py
+++ b/bloonspy/model/btd6/Progress.py
@@ -710,6 +710,7 @@ class Achievement(Enum):
     BLOONTONA_500 = "Bloontona 500"
     SIDE_QUEST = "Side Quest"
     A_YEAR_IN_THE_MAKING = "A year in the making"
+    WORLD_LEAGUE_TRAINING = "World League Training"
 
     @staticmethod
     def from_string(value: str) -> "Achievement":

--- a/bloonspy/model/btd6/Score.py
+++ b/bloonspy/model/btd6/Score.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+import warnings
 from datetime import timedelta
 from enum import Enum
 from typing import Dict, Any
@@ -7,17 +8,31 @@ from typing import Dict, Any
 class ScoreType(Enum):
     """Ways to judge how good a player did in events."""
     GAME_TIME = "Game Time"
-    CASH_SPENT = "Cash Spent"
-    TIERS = "Tiers"
+    LEAST_CASH = "Least Cash"
+    LEAST_TIERS = "Least Tiers"
     TIME_AFTER_EVENT_START = "Time After Event Start"
+
+    @staticmethod
+    @property
+    def CASH_SPENT():
+        warnings.warn("ScoreType.CASH_SPENT is deprecated, please use ScoreType.LEAST_CASH instead.")
+        return ScoreType.LEAST_CASH
+
+    @staticmethod
+    @property
+    def TIERS():
+        warnings.warn("ScoreType.TIERS is deprecated, please use ScoreType.LEAST_TIERS instead.")
+        return ScoreType.LEAST_TIERS
 
     @staticmethod
     def from_string(value: str) -> "ScoreType":
         score_type_switch = {
             "GameTime": ScoreType.GAME_TIME,
-            "CashSpent": ScoreType.CASH_SPENT,
-            "Tiers": ScoreType.TIERS,
+            "CashSpent": ScoreType.LEAST_CASH,
+            "Tiers": ScoreType.LEAST_TIERS,
             "Time after event start": ScoreType.TIME_AFTER_EVENT_START,
+            "LeastCash": ScoreType.LEAST_CASH,
+            "LeastTiers": ScoreType.LEAST_TIERS,
         }
         if value in score_type_switch:
             return score_type_switch[value]
@@ -29,7 +44,32 @@ class ScoreType(Enum):
 
 @dataclass
 class Score:
-    """An event score."""
+    """
+    An event score.
+
+    .. container:: operations
+
+       .. describe:: x == y
+
+          Checks if the Score is equal to another Score.
+
+       .. describe:: x >= y
+
+          Checks if the Score is greater or equal than another Score.
+
+       .. describe:: x <= y
+
+          Checks if the Score is less or equal than another Score.
+
+       .. describe:: x > y
+
+          Checks if the Score is greater than another Score.
+
+       .. describe:: x < y
+
+          Checks if the Score is less than another Score.
+
+    """
     type: ScoreType  #: What the score represents.
     value: int | timedelta  #: The actual score value.
 
@@ -43,9 +83,9 @@ class Score:
         )
 
     def __str__(self) -> str:
-        if self.type == ScoreType.CASH_SPENT:
+        if self.type == ScoreType.LEAST_CASH:
             return f"${self.value:,}"
-        elif self.type == ScoreType.TIERS:
+        elif self.type == ScoreType.LEAST_TIERS:
             return f"{self.value:,}"
         return str(self.value)
 

--- a/bloonspy/model/btd6/User.py
+++ b/bloonspy/model/btd6/User.py
@@ -7,7 +7,7 @@ from ..Loadable import Loadable
 from ..Asset import Asset
 from .Tower import Tower
 from .UserSave import UserSave
-from .Medals import EventMedals, MapMedals, CTGlobalMedals, CTLocalMedals
+from .Medals import EventMedals, MapMedals, CtGlobalMedals, CtLocalMedals
 
 
 @dataclass(kw_only=True)
@@ -114,10 +114,10 @@ class User(Loadable):
             ("GoldSilver", "top_10_percent"), ("DoubleSilver", "top_25_percent"), ("Silver", "top_50_percent"),
             ("Bronze", "top_75_percent")
         ]
-        self._data["ct_local_medals"] = CTLocalMedals(
+        self._data["ct_local_medals"] = CtLocalMedals(
             **rename_keys(raw_user["_medalsCTLocal"], ct_local_medal_keys)
         )
-        self._data["ct_global_medals"] = CTGlobalMedals(
+        self._data["ct_global_medals"] = CtGlobalMedals(
             **rename_keys(raw_user["_medalsCTLocal"], ct_global_medal_keys)
         )
 
@@ -250,13 +250,13 @@ class User(Loadable):
 
     @property
     @fetch_property(Loadable.load_resource)
-    def ct_local_medals(self) -> CTLocalMedals:
+    def ct_local_medals(self) -> CtLocalMedals:
         """Contested Territory local medals."""
         return self._data["ct_local_medals"]
 
     @property
     @fetch_property(Loadable.load_resource)
-    def ct_global_medals(self) -> CTGlobalMedals:
+    def ct_global_medals(self) -> CtGlobalMedals:
         """Contested Territory global medals."""
         return self._data["ct_global_medals"]
 

--- a/bloonspy/model/btd6/__init__.py
+++ b/bloonspy/model/btd6/__init__.py
@@ -1,19 +1,21 @@
-from .Boss import *
-from .Challenge import *
+from .Boss import Boss, BossBloon, BossEvent, BossPlayer, BossPlayerTeam
+from .Challenge import Challenge, ChallengeModifier, ChallengeFilter
 from .ContestedTerritory import ContestedTerritoryEvent, CtTile, CtTileType, GameType, CtTeam, CtPlayer, Relic
-from .Gamemode import *
-from .Medals import *
-from .Odyssey import *
-from .Power import *
-from .Race import *
-from .Restriction import *
-from .Team import *
-from .Tower import *
-from .User import *
-from .Score import *
+from .Gamemode import Gamemode, Difficulty, Mode
+from .Medals import MapMedals, EventMedals, CtGlobalMedals, CtLocalMedals, \
+    CTLocalMedals, CTGlobalMedals
+from .Odyssey import Odyssey, OdysseyDifficulty, OdysseyEvent
+from .Power import Power, PowerAmount
+from .Race import Race, RacePlayer
+from .Restriction import Restriction, TowerRestriction
+from .Team import Team, TeamStatus
+from .Tower import Tower, HeroSkin
+from .User import User, UserSave, GameplayStats
+from .Score import Score, ScoreType
 from .Cosmetics import TrophyStoreItemStatus, HeroPlacementFx, PowerSkins, TowerPets, TowerProjectiles, \
     VillageFlagCosmetics, MusicTracks, AllMonkeyFx, CoopEmotes, BloonsPopFx, BloonDecals, MoabSkins
 from .Map import MapProgress, MapBorder, Map, GamemodeCompletionData
 from .Progress import Upgrade, Achievement, MonkeyKnowledge
 from .UserSave import UserSave
 from .CustomMap import CustomMap, CustomMapFilter
+from .Rewards import InstaMonkey, Reward

--- a/docs/source/pages/api.rst
+++ b/docs/source/pages/api.rst
@@ -186,7 +186,7 @@ EventMedals
 .. autoclass:: bloonspy.model.btd6.EventMedals()
    :members:
 
-CTLocalMedals
+CtLocalMedals
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. autoclass:: bloonspy.model.btd6.CTLocalMedals()
@@ -195,7 +195,7 @@ CTLocalMedals
 CTGlobalMedals
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. autoclass:: bloonspy.model.btd6.CTGlobalMedals()
+.. autoclass:: bloonspy.model.btd6.CtGlobalMedals()
    :members:
 
 MapMedals

--- a/tests/integration/test_fetch_user.py
+++ b/tests/integration/test_fetch_user.py
@@ -1,5 +1,6 @@
 import unittest
 from bloonspy import btd6, Client
+from bloonspy.model import Asset
 
 
 class TestFetchTeamOwner(unittest.TestCase):
@@ -13,10 +14,10 @@ class TestFetchTeamOwner(unittest.TestCase):
         check_instance = [
             ("followers", int),
             ("name", str),
-            ("banner", btd6.Asset),
+            ("banner", Asset),
             ("single_player_medals", btd6.MapMedals),
             ("boss_normal_medals", btd6.EventMedals),
-            ("ct_local_medals", btd6.CTLocalMedals),
+            ("ct_local_medals", btd6.CtLocalMedals),
             ("stats", btd6.GameplayStats),
         ]
         for attr_name, attr_type in check_instance:

--- a/tests/integration/test_team_owner.py
+++ b/tests/integration/test_team_owner.py
@@ -1,5 +1,5 @@
 import unittest
-from bloonspy import btd6, Client
+from bloonspy import Client
 
 
 class TestTeamOwner(unittest.TestCase):
@@ -7,17 +7,11 @@ class TestTeamOwner(unittest.TestCase):
         """
         Test getting a team's owner.
         """
-        team_id = "9fbd42d98ac2faa41d40884a5b21b577cb064ebacf168e3f"
+        team_id = "9fba1683de92f9f01c4b861d5c70e326ce571db4ca448b30"#"9fbd42d98ac2faa41d40884a5b21b577cb064ebacf168e3f"
         team = Client.get_team(team_id)
         owner = team.owner()
         self.assertIsNotNone(owner)
-        self.assertIn(owner.name.lower(), ["thargos", "vaneckpm"])
-
-    # Unlucky for me I know none of these.
-    # def test_team_disbanded(self) -> None:
-    #     """
-    #     Test a challenge with a missing creator.
-    #     """
+        self.assertIn(owner.name.lower(), ["zoroark", "thargos", "vaneckpm"])
 
 
 if __name__ == '__main__':

--- a/tests/unit/test_boss.py
+++ b/tests/unit/test_boss.py
@@ -2,6 +2,7 @@ import unittest
 from datetime import datetime
 import requests
 from bloonspy import btd6
+from bloonspy.exceptions import NotFound
 
 
 class TestBoss(unittest.TestCase):
@@ -44,7 +45,7 @@ class TestBoss(unittest.TestCase):
         correct_exception = False
         try:
             btd6.BossEvent(boss_id, eager=True)
-        except btd6.NotFound:
+        except NotFound:
             correct_exception = True
         self.assertTrue(correct_exception, msg="Wrong/expired boss IDs should raise bloonspy.exceptions.NotFound")
 

--- a/tests/unit/test_challenge.py
+++ b/tests/unit/test_challenge.py
@@ -1,7 +1,8 @@
 import unittest
 from datetime import datetime
 import bloonspy
-from bloonspy import btd6
+from bloonspy import btd6, model
+from bloonspy.exceptions import NotFound
 
 
 class TestChallenge(unittest.TestCase):
@@ -16,7 +17,7 @@ class TestChallenge(unittest.TestCase):
             ("id", "ZMDCDTB"),
             ("name", "CT10 Tile CBA"),
             ("created_at", datetime.fromtimestamp(int(1671727285722/1000))),
-            ("game_version", btd6.GameVersion(34, 3)),
+            ("game_version", model.GameVersion(34, 3)),
             ("gamemode", btd6.Gamemode(btd6.Difficulty.MEDIUM, btd6.Mode.STANDARD)),
             ("disable_double_cash", True),
             ("disable_monkey_knowledge", False),
@@ -29,7 +30,7 @@ class TestChallenge(unittest.TestCase):
             ("least_tiers_used", 10),
             ("seed", 771803684),
             ("starting_lives", 150),
-            ("max_lives", 9999),
+            ("max_lives", 5000),
             ("start_round", 1),
             ("end_round", 51),
             ("max_towers", 9999),
@@ -56,7 +57,7 @@ class TestChallenge(unittest.TestCase):
             )
 
         no_restrictions = btd6.TowerRestriction(
-            max_towers=btd6.Infinity(),
+            max_towers=bloonspy.Infinity(),
             top_path_blocked=0,
             middle_path_blocked=0,
             bottom_path_blocked=0,
@@ -87,7 +88,7 @@ class TestChallenge(unittest.TestCase):
                 msg=f"Assert if {power.value} appears in the powers list"
             )
             self.assertEqual(
-                challenge.powers[power], btd6.Infinity(),
+                challenge.powers[power], bloonspy.Infinity(),
                 msg=f"Assert if {power.value} is allowed infinite times"
             )
 
@@ -99,7 +100,7 @@ class TestChallenge(unittest.TestCase):
         correct_exception = False
         try:
             btd6.Challenge(challenge_code, eager=True)
-        except btd6.NotFound:
+        except NotFound:
             correct_exception = True
         self.assertTrue(correct_exception, msg="Wrong challenges IDs should raise bloonspy.exceptions.NotFound")
 

--- a/tests/unit/test_ct.py
+++ b/tests/unit/test_ct.py
@@ -2,6 +2,7 @@ import unittest
 from datetime import datetime
 import requests
 from bloonspy import btd6
+from bloonspy.exceptions import NotFound
 
 
 class TestCt(unittest.TestCase):
@@ -42,7 +43,7 @@ class TestCt(unittest.TestCase):
         correct_exception = False
         try:
             btd6.ContestedTerritoryEvent(ct_id, eager=True)
-        except btd6.NotFound:
+        except NotFound:
             correct_exception = True
         self.assertTrue(correct_exception, msg="Wrong/expired CT IDs should raise bloonspy.exceptions.NotFound")
 

--- a/tests/unit/test_custom_map.py
+++ b/tests/unit/test_custom_map.py
@@ -1,6 +1,8 @@
 import unittest
 from datetime import datetime
 from bloonspy import btd6
+from bloonspy.model import GameVersion
+from bloonspy.exceptions import NotFound
 
 
 class TestCustomMap(unittest.TestCase):
@@ -15,7 +17,7 @@ class TestCustomMap(unittest.TestCase):
             ("id", map_code),
             ("name", "Mapa de PowerDino3423"),
             ("created_at", datetime.fromtimestamp(int(1697220116593/1000))),
-            ("game_version", btd6.GameVersion(39, 0)),
+            ("game_version", GameVersion(39, 0)),
         ]
         for attr_name, attr_expected_value in expected_results:
             self.assertEqual(
@@ -45,7 +47,7 @@ class TestCustomMap(unittest.TestCase):
         correct_exception = False
         try:
             btd6.CustomMap(map_code, eager=True)
-        except btd6.NotFound:
+        except NotFound:
             correct_exception = True
         self.assertTrue(correct_exception, msg="Wrong map IDs should raise bloonspy.exceptions.NotFound")
 

--- a/tests/unit/test_odyssey.py
+++ b/tests/unit/test_odyssey.py
@@ -1,8 +1,8 @@
 import unittest
 from datetime import datetime
 import requests
-import bloonspy
 from bloonspy import btd6
+from bloonspy.exceptions import NotFound
 
 
 class TestOdyssey(unittest.TestCase):
@@ -71,7 +71,7 @@ class TestOdyssey(unittest.TestCase):
         correct_exception = False
         try:
             btd6.OdysseyEvent(team_id, eager=True)
-        except btd6.NotFound:
+        except NotFound:
             correct_exception = True
         self.assertTrue(correct_exception, msg="Wrong odyssey IDs should raise bloonspy.exceptions.NotFound")
 

--- a/tests/unit/test_race.py
+++ b/tests/unit/test_race.py
@@ -2,6 +2,7 @@ import unittest
 from datetime import datetime
 import requests
 from bloonspy import btd6
+from bloonspy.exceptions import NotFound
 
 
 class TestRace(unittest.TestCase):
@@ -29,7 +30,7 @@ class TestRace(unittest.TestCase):
         correct_exception = False
         try:
             btd6.Race(race_id, eager=True)
-        except btd6.NotFound:
+        except NotFound:
             correct_exception = True
         self.assertTrue(correct_exception, msg="Wrong/expired race IDs should raise bloonspy.exceptions.NotFound")
 

--- a/tests/unit/test_team.py
+++ b/tests/unit/test_team.py
@@ -1,5 +1,7 @@
 import unittest
 from bloonspy import btd6
+from bloonspy.exceptions import NotFound
+from bloonspy.model import Asset
 
 
 class TestTeam(unittest.TestCase):
@@ -24,8 +26,7 @@ class TestTeam(unittest.TestCase):
                              msg=f"Check Team.member_count within higher bound")
 
         check_instance = [
-            ("status", btd6.TeamStatus), ("icon", btd6.Asset), ("banner", btd6.Asset),
-            ("frame", btd6.Asset),
+            ("status", btd6.TeamStatus), ("icon", Asset), ("banner", Asset), ("frame", Asset),
         ]
         for attr_name, attr_type in check_instance:
             self.assertIsInstance(getattr(team, attr_name), attr_type,
@@ -39,7 +40,7 @@ class TestTeam(unittest.TestCase):
         correct_exception = False
         try:
             btd6.Team(team_id, eager=True)
-        except btd6.NotFound:
+        except NotFound:
             correct_exception = True
         self.assertTrue(correct_exception, msg="Wrong team IDs should raise bloonspy.exceptions.NotFound")
 

--- a/tests/unit/test_user.py
+++ b/tests/unit/test_user.py
@@ -1,5 +1,7 @@
 import unittest
 from bloonspy import btd6
+from bloonspy.exceptions import NotFound
+from bloonspy.model import Asset
 
 
 class TestUser(unittest.TestCase):
@@ -30,15 +32,15 @@ class TestUser(unittest.TestCase):
 
         check_instance = [
             ("followers", int),
-            ("avatar", btd6.Asset),
-            ("banner", btd6.Asset),
+            ("avatar", Asset),
+            ("banner", Asset),
             ("single_player_medals", btd6.MapMedals),
             ("coop_medals", btd6.MapMedals),
             ("boss_normal_medals", btd6.EventMedals),
             ("boss_elite_medals", btd6.EventMedals),
             ("race_medals", btd6.EventMedals),
-            ("ct_local_medals", btd6.CTLocalMedals),
-            ("ct_global_medals", btd6.CTGlobalMedals),
+            ("ct_local_medals", btd6.CtLocalMedals),
+            ("ct_global_medals", btd6.CtGlobalMedals),
             ("stats", btd6.GameplayStats),
         ]
         for attr_name, attr_type in check_instance:
@@ -137,7 +139,7 @@ class TestUser(unittest.TestCase):
         correct_exception = False
         try:
             btd6.User(user_id, eager=True)
-        except btd6.NotFound:
+        except NotFound:
             correct_exception = True
         self.assertTrue(correct_exception, msg="Wrong user IDs should raise bloonspy.exceptions.NotFound")
 

--- a/tests/unit/test_usersave.py
+++ b/tests/unit/test_usersave.py
@@ -1,6 +1,6 @@
 import unittest
-from pprint import pp
 from bloonspy import btd6
+from bloonspy.exceptions import NotFound
 
 
 class TestUserSave(unittest.TestCase):
@@ -25,7 +25,7 @@ class TestUserSave(unittest.TestCase):
         # Greater or Equal cause these can increase in the future.
         expected_results_ge = [
             ("games_played", 2894),
-            ("monkey_money", 28470),
+            ("monkey_money", 5000),
             ("rank", 155),
             ("veteran_xp", 161489560),
             ("veteran_rank", 9),
@@ -136,7 +136,7 @@ class TestUserSave(unittest.TestCase):
         correct_exception = False
         try:
             btd6.UserSave.fetch(oak)
-        except btd6.NotFound:
+        except NotFound:
             correct_exception = True
         self.assertTrue(correct_exception, msg="Wrong OAKs should raise bloonspy.exceptions.NotFound")
 


### PR DESCRIPTION

### Changed
- `CTGlobalMedals` renamed to `CtGlobalMedals`
- `CTLocalMedals` renamed to `CtLocalMedals`
- `ScoreType.CASH_SPENT` renamed to `ScoreType.LEAST_CASH`
- `ScoreType.TIERS` renamed to `ScoreType.LEAST_TIERS`
- `BossEvent.score_type` should be properly fetched when trying to access it through a non-eager instance.
- `bloonspy.model.btd6` exports fixed to not import everything
- Added `Achievement.WORLD_LEAGUE_TRAINING`