### PR TITLE
BloonsPy 0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+# [0.8.1](https://pypi.org/project/bloonspy/0.8.1) - 2023-12-19
+
+### Fixed
+- `CtTiles` with relics `Relic.MOAB_MINE` and `Relic.MOAB_CLASH` should correctly have the `relic` 
+property assigned instead of it being `None`
+
 ## [0.8.0](https://pypi.org/project/bloonspy/0.8.0) - 2023-11-18
 
 ### Changed

--- a/bloonspy/__init__.py
+++ b/bloonspy/__init__.py
@@ -2,5 +2,5 @@ from .Client import *
 from .model import btd6
 from .utils import Infinity
 
-__version__ = "0.8.0"
+__version__ = "0.8.1"
 __author__ = "TheSartorsss"

--- a/bloonspy/model/btd6/ContestedTerritory.py
+++ b/bloonspy/model/btd6/ContestedTerritory.py
@@ -150,6 +150,8 @@ class Relic(Enum):
 rel_switch = {}
 for rel in Relic:
     rel_switch[rel.value.replace(" ", "")] = rel
+rel_switch["MoabMine"] = Relic.MOAB_MINE
+rel_switch["MoabClash"] = Relic.MOAB_CLASH
 
 
 @dataclass

--- a/bloonspy/model/btd6/ContestedTerritory.py
+++ b/bloonspy/model/btd6/ContestedTerritory.py
@@ -147,11 +147,9 @@ class Relic(Enum):
         return rel_switch[value] if value in rel_switch else None
 
 
-rel_switch = {}
+rel_switch = {"MoabMine": Relic.MOAB_MINE, "MoabClash": Relic.MOAB_CLASH}
 for rel in Relic:
     rel_switch[rel.value.replace(" ", "")] = rel
-rel_switch["MoabMine"] = Relic.MOAB_MINE
-rel_switch["MoabClash"] = Relic.MOAB_CLASH
 
 
 @dataclass

--- a/tests/unit/test_ct.py
+++ b/tests/unit/test_ct.py
@@ -34,6 +34,8 @@ class TestCt(unittest.TestCase):
         for t in tiles:
             self.assertIsInstance(t, btd6.CtTile)
             self.assertEqual(len(t.id), 3)
+            if t.tile_type == btd6.CtTileType.RELIC:
+                self.assertIsInstance(t.relic, btd6.Relic, msg=f"Tile {t} is not btd6.Relic but is {t.relic}")
 
     def test_ct_fail(self) -> None:
         """


### PR DESCRIPTION

### Fixed
- `CtTiles` with relics `Relic.MOAB_MINE` and `Relic.MOAB_CLASH` should correctly have the `relic`
property assigned instead of it being `None`