### PR TITLE
V0.9.1

### DIFF
--- a/.pytest.ini
+++ b/.pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+asyncio_mode = auto
+asyncio_default_fixture_loop_scope = function

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+# [0.9.1](https://pypi.org/project/bloonspy/0.9.0) - 2024-09-27
+
+### Fixed
+- `ContestedTerritoryEvent` loads correctly from `Client.contested_territories()`
+
+### Removed
+- `AsyncClient`'s `aiohttp_client` parameter is mandatory, will no longer create one if not provided. This will be added in a future release, with `async with` support.
+
 # [0.9.0](https://pypi.org/project/bloonspy/0.9.0) - 2024-09-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+# [0.9.0](https://pypi.org/project/bloonspy/0.9.0) - 2024-09-27
+
+### Added
+- Native `async` support
+
 # [0.8.1](https://pypi.org/project/bloonspy/0.8.1) - 2023-12-19
 
 ### Fixed

--- a/bloonspy/AsyncClient.py
+++ b/bloonspy/AsyncClient.py
@@ -28,7 +28,7 @@ class AsyncClient:
             asyncio.create_task(self.__create_aclient())
 
     async def __create_aclient(self):
-        with aiohttp.ClientSession() as aclient:
+        async with aiohttp.ClientSession() as aclient:
             self.__aclient = aclient
             await asyncio.Future()
 

--- a/bloonspy/AsyncClient.py
+++ b/bloonspy/AsyncClient.py
@@ -1,0 +1,310 @@
+import asyncio
+from typing import List
+from concurrent.futures import ThreadPoolExecutor
+import aiohttp
+from .utils.asyncapi import aget
+from .model.btd6 import \
+    OdysseyEvent, \
+    BossEvent, \
+    Race, \
+    ContestedTerritoryEvent, Team, \
+    Challenge, ChallengeFilter, \
+    User, \
+    CustomMap, CustomMapFilter
+
+
+class Client:
+    """Client for all API calls.
+
+    :param open_access_key: Your OAK for the Ninja Kiwi Open Data API.
+    :type open_access_key: str
+    :param aiohttp_client: An aiohttp Client. Will create one if not provided.
+    :type aiohttp_client: aiohttp.ClientSession
+    """
+
+    def __init__(self, open_access_key: str, aiohttp_client: aiohttp.ClientSession = None):
+        self.__oak = open_access_key
+        self.__aclient = aiohttp_client
+        if self.__aclient is None:
+            asyncio.create_task(self.__create_aclient())
+
+    async def __create_aclient(self):
+        with aiohttp.ClientSession() as aclient:
+            self.__aclient = aclient
+            await asyncio.Future()
+
+    async def odysseys(self) -> List[OdysseyEvent]:
+        """Get a list of Odyssey events."""
+        odysseys_data = await aget(self.__aclient, "/btd6/odyssey")
+        odyssey_list = []
+        for odyssey in odysseys_data:
+            odyssey_list.append(OdysseyEvent(odyssey["id"], event_json=odyssey))
+        return odyssey_list
+
+    async def get_odyssey(self, odyssey_id: str, eager: bool = False) -> OdysseyEvent:
+        """Fetch a specific Odyssey by its ID.
+
+        .. note::
+           If lazy loaded, the returned :class:`~bloonspy.model.btd6.OdysseyEvent` object will only
+           have the property :attr:`~bloonspy.model.Event.id` loaded.
+
+        :param odyssey_id: The ID of the odyssey.
+        :type odyssey_id: str
+        :param eager: If `True`, it loads all of the data right away. Set it to `False`
+            if you want to limit API calls and don't need all the data. For more information,
+            please read `Lazy and Eager Loading <async.html#lazy-and-eager-loading>`_.
+        :type eager: bool
+
+        :return: The found odyssey.
+        :rtype: ~bloonspy.model.btd6.OdysseyEvent
+
+        :raise ~bloonspy.exceptions.NotFound: If no odyssey with that ID is found.
+        """
+        return OdysseyEvent(odyssey_id, eager=eager)
+
+    def contested_territories(self) -> List[ContestedTerritoryEvent]:
+        """Get a list of Contested Territory events."""
+        ct_data = await aget(self.__aclient, "/btd6/ct")
+        ct_list = []
+        for ct in ct_data:
+            ct_list.append(ContestedTerritoryEvent(ct["id"], event_json=ct))
+        return ct_list
+
+    @staticmethod
+    def get_contested_territory(ct_id: str, eager: bool = False) -> ContestedTerritoryEvent:
+        """Fetch a specific Contested Territory event by its ID.
+
+        .. note::
+           If lazy loaded, the returned :class:`~bloonspy.model.btd6.ContestedTerritoryEvent` object will only
+           have the property :attr:`~bloonspy.model.Lodable.id` loaded.
+
+        :param ct_id: The ID of the event.
+        :type ct_id: str
+        :param eager: If `True`, it loads all of the data right away. Set it to `False`
+            if you want to limit API calls and don't need all the data. For more information,
+            please read `Lazy and Eager Loading <async.html#lazy-and-eager-loading>`_.
+        :type eager: bool
+
+        :return: The found Contested Territory event.
+        :rtype: ~bloonspy.model.btd6.ContestedTerritoryEvent
+
+        :raise ~bloonspy.exceptions.NotFound: If no CT with that ID is found.
+        """
+        return ContestedTerritoryEvent(ct_id, eager=eager)
+
+    @staticmethod
+    def get_team(team_id: str) -> Team:
+        """Fetch a specific team by its ID.
+
+        :param team_id: The ID of the team.
+        :type team_id: str
+
+        :return: The found team.
+        :rtype: ~bloonspy.model.btd6.Team
+
+        :raise ~bloonspy.exceptions.NotFound: If no team with that ID is found.
+        """
+        return Team(team_id, eager=True)
+
+    def races(self) -> List[Race]:
+        """Get a list of Race events.
+
+        .. note::
+           The returned :class:`~bloonspy.model.btd6.Race` objects will only
+           have the properties :attr:`~bloonspy.model.Loadable.id`, :attr:`~bloonspy.model.btd6.Race.name`,
+           :attr:`~bloonspy.model.btd6.Race.start`, :attr:`~bloonspy.model.btd6.Race.end`, and
+           :attr:`~bloonspy.model.btd6.Race.total_scores` loaded.
+        """
+        races_data = await aget(self.__aclient, "/btd6/races")
+        race_list = []
+        for race in races_data:
+            race_list.append(Race(race["id"], race_json=race))
+        return race_list
+
+    @staticmethod
+    def get_race(race_id: str, eager: bool = False) -> Race:
+        """Fetch a specific Race by its ID.
+
+        .. note::
+           If lazy loaded, the returned :class:`~bloonspy.model.btd6.Race` objects will only
+           have the properties :attr:`~bloonspy.model.Loadable.id` loaded.
+
+        :param race_id: The ID of the race.
+        :type race_id: str
+        :param eager: If `True`, it loads all of the data right away. Set it to `False`
+            if you want to limit API calls and don't need all the data. For more information,
+            please read `Lazy and Eager Loading <async.html#lazy-and-eager-loading>`_.
+        :type eager: bool
+
+        :return: The found race.
+        :rtype: ~bloonspy.model.btd6.Race
+
+        :raise ~bloonspy.exceptions.NotFound: If no race with that ID is found.
+        """
+        return Race(race_id, eager=eager)
+
+    def bosses(self) -> List[BossEvent]:
+        """Get a list of Boss events."""
+        bosses_data = await aget(self.__aclient, "/btd6/bosses")
+        boss_list = []
+        for boss in bosses_data:
+            boss_list.append(BossEvent(boss["id"], event_json=boss))
+        return boss_list
+
+    @staticmethod
+    def get_boss(boss_id: str, eager: bool = False) -> BossEvent:
+        """Fetch a specific Boss event by its ID.
+
+        .. note::
+           If lazy loaded, the returned :class:`~bloonspy.model.btd6.BossEvent` objects will only
+           have the property :attr:`~bloonspy.model.Loadable.id` loaded.
+
+        :param boss_id: The boss ID.
+        :type boss_id: str
+        :param eager: If `True`, it loads all of the data right away. Set it to `False`
+            if you want to limit API calls and don't need all the data. For more information,
+            please read `Lazy and Eager Loading <async.html#lazy-and-eager-loading>`_.
+        :type eager: bool
+
+        :return: The found Boss event.
+        :rtype: ~bloonspy.model.btd6.BossEvent
+
+        :raise ~bloonspy.exceptions.NotFound: If no boss event with that ID is found.
+        """
+        return BossEvent(boss_id, eager=eager)
+
+    def challenges(self, challenge_filter: ChallengeFilter, pages: int = 1, start_from_page: int = 1) -> List[Challenge]:
+        """Get a list of challenges given a specific filter.
+
+        .. note::
+           The returned :class:`~bloonspy.model.btd6.Challenge` objects will only
+           have the properties :attr:`~bloonspy.model.Loadable.id`, :attr:`~bloonspy.model.btd6.Challenge.name`,
+           :attr:`~bloonspy.model.Challenge.created_at`, and :attr:`~bloonspy.model.Challenge.creator_id` loaded.
+
+        :param challenge_filter: Which type of challenges you'd like to see.
+        :type challenge_filter: ~bloonspy.model.btd6.ChallengeFilter
+        :param pages: The number of pages to fetch.
+        :type pages: int
+        :param start_from_page: The page to start fetching from.
+        :type start_from_page: int
+
+        :return: A list of challenges (lazy loaded).
+        :rtype: List[:class:`bloonspy.model.btd6.Challenge`]
+        """
+
+        challenge_list = []
+        challenge_pages = []
+
+        async def get_page(page_num: int) -> None:
+            nonlocal challenge_pages
+            challenge_pages.append(
+                await aget(
+                    self.__aclient,
+                    f"/btd6/challenges/filter/{challenge_filter.value}",
+                    {"page": page_num}
+                )
+            )
+
+        await asyncio.gather(*[
+            get_page(page_num) for page_num in range(start_from_page, start_from_page + pages)
+        ])
+
+        for page in challenge_pages:
+            for chlg in page:
+                challenge_list.append(Challenge(chlg["id"], name=chlg["name"], created_at=chlg["createdAt"],
+                                                creator_id=chlg["creator"].split("/")[-1]))
+
+        # Make async
+        # if eager:
+        #     with ThreadPoolExecutor(max_workers=10) as executor:
+        #         futures = []
+        #         for challenge in challenge_list:
+        #             futures.append(executor.submit(challenge.load_resource))
+        #         concurrent.futures.wait(futures)
+
+        return challenge_list
+
+    @staticmethod
+    def get_challenge(challenge_id: str) -> Challenge:
+        """Fetch a specific challenge by its ID.
+
+        :param challenge_id: The challenge ID.
+        :type challenge_id: str
+
+        :return: The found challenge.
+        :rtype: ~bloonspy.model.btd6.Challenge
+
+        :raise ~bloonspy.exceptions.NotFound: If no challenge with the given ID is found.
+        """
+        return Challenge(challenge_id, eager=True)
+
+    @staticmethod
+    def get_user(identifier: str) -> User:
+        """Fetch a specific user by an identifier.
+
+        :param identifier: The user ID, or its OAK.
+        :type identifier: str
+
+        :return: The found user.
+        :rtype: ~bloonspy.model.btd6.User
+
+        :raise ~bloonspy.exceptions.NotFound: If no user with the given ID/OAK is found.
+        """
+        return User(identifier, eager=True)
+
+    @staticmethod
+    def get_custom_map(map_id: str) -> CustomMap:
+        """Fetch a specific custom map by its ID.
+
+        :param map_id: The challenge ID.
+        :type map_id: str
+
+        :return: The found map.
+        :rtype: ~bloonspy.model.btd6.CustomMap
+
+        :raise ~bloonspy.exceptions.NotFound: If no custom map with the given ID is found.
+        """
+        return CustomMap(map_id, eager=True)
+
+    def custom_maps(self, custom_map_fliter: CustomMapFilter, pages: int = 1, start_from_page: int = 1) -> List[CustomMap]:
+        """Get a list of challenges given a specific filter.
+
+        .. note::
+           The returned :class:`~bloonspy.model.btd6.CustomMap` objects will only
+           have the properties :attr:`~bloonspy.model.Loadable.id`, :attr:`~bloonspy.model.btd6.CustomMap.name`,
+           and :attr:`~bloonspy.model.CustomMap.created_at` loaded.
+
+        :param custom_map_fliter: Which type of custom maps you'd like to see.
+        :type custom_map_fliter: ~bloonspy.model.btd6.CustomMapFilter
+        :param pages: The number of pages to fetch.
+        :type pages: int
+        :param start_from_page: The page to start fetching from.
+        :type start_from_page: int
+
+        :return: A list of custom maps (lazy loaded).
+        :rtype: List[:class:`bloonspy.model.btd6.CustomMap`]
+        """
+
+        custom_map_list = []
+        custom_map_pages = []
+
+        async def get_page(page_num: int) -> None:
+            nonlocal custom_map_pages
+            custom_map_pages.append(
+                await aget(
+                    self.__aclient,
+                    f"/btd6/maps/filter/{custom_map_fliter.value}",
+                    {"page": page_num}
+                )
+            )
+
+        await asyncio.gather(*[
+            get_page(page_num) for page_num in range(start_from_page, start_from_page + pages)
+        ])
+
+        for page in custom_map_pages:
+            for cmap in page:
+                custom_map_list.append(CustomMap(cmap["id"], name=cmap["name"], created_at=cmap["createdAt"],
+                                                 creator_id=cmap["creator"].split("/")[-1]))
+
+        return custom_map_list

--- a/bloonspy/AsyncClient.py
+++ b/bloonspy/AsyncClient.py
@@ -24,32 +24,33 @@ class AsyncClient:
        properties do not have to be awaited. Only methods do.
        **If you have to use parenthesis, you should await.**
 
+    :param aiohttp_client: An aiohttp Client.
+    :type aiohttp_client: aiohttp.ClientSession
     :param open_access_key: Your OAK for the Ninja Kiwi Open Data API.
     :type open_access_key: str
-    :param aiohttp_client: An aiohttp Client. Will create one if not provided.
-    :type aiohttp_client: aiohttp.ClientSession
     """
 
-    def __init__(self, open_access_key: str = None, aiohttp_client: aiohttp.ClientSession = None):
+    def __init__(self, aiohttp_client: aiohttp.ClientSession, open_access_key: str = None):
         self.__oak = open_access_key
-        self.__aclient = aiohttp_client
-        if self.__aclient is None:
-            asyncio.create_task(self.__create_aclient())
+        self._async_client = aiohttp_client
+        # if self._async_client is None:
+        #     asyncio.create_task(self._create_async_client())
 
-    async def __create_aclient(self):
-        async with aiohttp.ClientSession() as aclient:
-            self.__aclient = aclient
-            await asyncio.Future()
+    # async def _create_async_client(self):
+    #     async with aiohttp.ClientSession() as aclient:
+    #         self._async_client = aclient
+    #         while True:
+    #             await asyncio.sleep(60)
 
     async def odysseys(self) -> list[OdysseyEvent]:
         """Get a list of Odyssey events."""
-        odysseys_data = await aget(self.__aclient, "/btd6/odyssey")
+        odysseys_data = await aget(self._async_client, "/btd6/odyssey")
         odyssey_list = []
         for odyssey in odysseys_data:
             odyssey_list.append(OdysseyEvent(
                 odyssey["id"],
                 event_json=odyssey,
-                async_client=self.__aclient,
+                async_client=self._async_client,
             ))
         return odyssey_list
 
@@ -72,20 +73,20 @@ class AsyncClient:
 
         :raise ~bloonspy.exceptions.NotFound: If no odyssey with that ID is found.
         """
-        odyssey = OdysseyEvent(odyssey_id, async_client=self.__aclient)
+        odyssey = OdysseyEvent(odyssey_id, async_client=self._async_client)
         if eager:
             await odyssey.load_event()
         return odyssey
 
     async def contested_territories(self) -> list[ContestedTerritoryEvent]:
         """Get a list of Contested Territory events."""
-        ct_data = await aget(self.__aclient, "/btd6/ct")
+        ct_data = await aget(self._async_client, "/btd6/ct")
         ct_list = []
         for ct in ct_data:
             ct_list.append(ContestedTerritoryEvent(
                 ct["id"],
                 event_json=ct,
-                async_client=self.__aclient,
+                async_client=self._async_client,
             ))
         return ct_list
 
@@ -108,7 +109,7 @@ class AsyncClient:
 
         :raise ~bloonspy.exceptions.NotFound: If no CT with that ID is found.
         """
-        ct = ContestedTerritoryEvent(ct_id, async_client=self.__aclient)
+        ct = ContestedTerritoryEvent(ct_id, async_client=self._async_client)
         if eager:
             await ct.load_event()
         return ct
@@ -124,7 +125,7 @@ class AsyncClient:
 
         :raise ~bloonspy.exceptions.NotFound: If no team with that ID is found.
         """
-        tm = Team(team_id, async_client=self.__aclient)
+        tm = Team(team_id, async_client=self._async_client)
         await tm.load_resource()
         return tm
 
@@ -137,13 +138,13 @@ class AsyncClient:
            :attr:`~bloonspy.model.btd6.Race.start`, :attr:`~bloonspy.model.btd6.Race.end`, and
            :attr:`~bloonspy.model.btd6.Race.total_scores` loaded.
         """
-        races_data = await aget(self.__aclient, "/btd6/races")
+        races_data = await aget(self._async_client, "/btd6/races")
         race_list = []
         for race in races_data:
             race_list.append(Race(
                 race["id"],
                 race_json=race,
-                async_client=self.__aclient,
+                async_client=self._async_client,
             ))
         return race_list
 
@@ -166,20 +167,20 @@ class AsyncClient:
 
         :raise ~bloonspy.exceptions.NotFound: If no race with that ID is found.
         """
-        race = Race(race_id, async_client=self.__aclient)
+        race = Race(race_id, async_client=self._async_client)
         if eager:
             await race.load_resource()
         return race
 
     async def bosses(self) -> list[BossEvent]:
         """Get a list of Boss events."""
-        bosses_data = await aget(self.__aclient, "/btd6/bosses")
+        bosses_data = await aget(self._async_client, "/btd6/bosses")
         boss_list = []
         for boss in bosses_data:
             boss_list.append(BossEvent(
                 boss["id"],
                 event_json=boss,
-                async_client=self.__aclient,
+                async_client=self._async_client,
             ))
         return boss_list
 
@@ -202,7 +203,7 @@ class AsyncClient:
 
         :raise ~bloonspy.exceptions.NotFound: If no boss event with that ID is found.
         """
-        boss = BossEvent(boss_id, async_client=self.__aclient)
+        boss = BossEvent(boss_id, async_client=self._async_client)
         if eager:
             await boss.load_event()
         return boss
@@ -238,7 +239,7 @@ class AsyncClient:
             nonlocal challenge_pages
             challenge_pages.append(
                 await aget(
-                    self.__aclient,
+                    self._async_client,
                     f"/btd6/challenges/filter/{challenge_filter.value}",
                     {"page": page_num}
                 )
@@ -274,7 +275,7 @@ class AsyncClient:
 
         :raise ~bloonspy.exceptions.NotFound: If no challenge with the given ID is found.
         """
-        chal = Challenge(challenge_id, async_client=self.__aclient)
+        chal = Challenge(challenge_id, async_client=self._async_client)
         await chal.load_resource()
         return chal
 
@@ -289,7 +290,7 @@ class AsyncClient:
 
         :raise ~bloonspy.exceptions.NotFound: If no user with the given ID/OAK is found.
         """
-        usr = User(identifier, async_client=self.__aclient)
+        usr = User(identifier, async_client=self._async_client)
         await usr.load_resource()
         return usr
 
@@ -304,7 +305,7 @@ class AsyncClient:
 
         :raise ~bloonspy.exceptions.NotFound: If no custom map with the given ID is found.
         """
-        cmap = CustomMap(map_id, async_client=self.__aclient)
+        cmap = CustomMap(map_id, async_client=self._async_client)
         await cmap.load_resource()
         return cmap
 
@@ -339,7 +340,7 @@ class AsyncClient:
             nonlocal custom_map_pages
             custom_map_pages.append(
                 await aget(
-                    self.__aclient,
+                    self._async_client,
                     f"/btd6/maps/filter/{custom_map_fliter.value}",
                     {"page": page_num}
                 )
@@ -356,7 +357,7 @@ class AsyncClient:
                     name=cmap["name"],
                     created_at=cmap["createdAt"],
                     creator_id=cmap["creator"].split("/")[-1],
-                    async_client=self.__aclient,
+                    async_client=self._async_client,
                 ))
 
         return custom_map_list

--- a/bloonspy/AsyncClient.py
+++ b/bloonspy/AsyncClient.py
@@ -1,6 +1,5 @@
 import asyncio
 from typing import List
-from concurrent.futures import ThreadPoolExecutor
 import aiohttp
 from .utils.asyncapi import aget
 from .model.btd6 import \
@@ -13,8 +12,8 @@ from .model.btd6 import \
     CustomMap, CustomMapFilter
 
 
-class Client:
-    """Client for all API calls.
+class AsyncClient:
+    """Client for all **asynchronous** API calls.
 
     :param open_access_key: Your OAK for the Ninja Kiwi Open Data API.
     :type open_access_key: str
@@ -22,7 +21,7 @@ class Client:
     :type aiohttp_client: aiohttp.ClientSession
     """
 
-    def __init__(self, open_access_key: str, aiohttp_client: aiohttp.ClientSession = None):
+    def __init__(self, open_access_key: str = None, aiohttp_client: aiohttp.ClientSession = None):
         self.__oak = open_access_key
         self.__aclient = aiohttp_client
         if self.__aclient is None:
@@ -62,7 +61,7 @@ class Client:
         """
         return OdysseyEvent(odyssey_id, eager=eager)
 
-    def contested_territories(self) -> List[ContestedTerritoryEvent]:
+    async def contested_territories(self) -> List[ContestedTerritoryEvent]:
         """Get a list of Contested Territory events."""
         ct_data = await aget(self.__aclient, "/btd6/ct")
         ct_list = []
@@ -106,7 +105,7 @@ class Client:
         """
         return Team(team_id, eager=True)
 
-    def races(self) -> List[Race]:
+    async def races(self) -> List[Race]:
         """Get a list of Race events.
 
         .. note::
@@ -143,7 +142,7 @@ class Client:
         """
         return Race(race_id, eager=eager)
 
-    def bosses(self) -> List[BossEvent]:
+    async def bosses(self) -> List[BossEvent]:
         """Get a list of Boss events."""
         bosses_data = await aget(self.__aclient, "/btd6/bosses")
         boss_list = []
@@ -173,7 +172,7 @@ class Client:
         """
         return BossEvent(boss_id, eager=eager)
 
-    def challenges(self, challenge_filter: ChallengeFilter, pages: int = 1, start_from_page: int = 1) -> List[Challenge]:
+    async def challenges(self, challenge_filter: ChallengeFilter, pages: int = 1, start_from_page: int = 1) -> List[Challenge]:
         """Get a list of challenges given a specific filter.
 
         .. note::
@@ -266,7 +265,7 @@ class Client:
         """
         return CustomMap(map_id, eager=True)
 
-    def custom_maps(self, custom_map_fliter: CustomMapFilter, pages: int = 1, start_from_page: int = 1) -> List[CustomMap]:
+    async def custom_maps(self, custom_map_fliter: CustomMapFilter, pages: int = 1, start_from_page: int = 1) -> List[CustomMap]:
         """Get a list of challenges given a specific filter.
 
         .. note::

--- a/bloonspy/AsyncClient.py
+++ b/bloonspy/AsyncClient.py
@@ -1,5 +1,4 @@
 import asyncio
-from typing import List
 import aiohttp
 from .utils.asyncapi import aget
 from .model.btd6 import \
@@ -37,7 +36,7 @@ class AsyncClient:
             self.__aclient = aclient
             await asyncio.Future()
 
-    async def odysseys(self) -> List[OdysseyEvent]:
+    async def odysseys(self) -> list[OdysseyEvent]:
         """Get a list of Odyssey events."""
         odysseys_data = await aget(self.__aclient, "/btd6/odyssey")
         odyssey_list = []
@@ -73,16 +72,19 @@ class AsyncClient:
             await odyssey.load_event()
         return odyssey
 
-    async def contested_territories(self) -> List[ContestedTerritoryEvent]:
+    async def contested_territories(self) -> list[ContestedTerritoryEvent]:
         """Get a list of Contested Territory events."""
         ct_data = await aget(self.__aclient, "/btd6/ct")
         ct_list = []
         for ct in ct_data:
-            ct_list.append(ContestedTerritoryEvent(ct["id"], event_json=ct))
+            ct_list.append(ContestedTerritoryEvent(
+                ct["id"],
+                event_json=ct,
+                async_client=self.__aclient,
+            ))
         return ct_list
 
-    @staticmethod
-    def get_contested_territory(ct_id: str, eager: bool = False) -> ContestedTerritoryEvent:
+    async def get_contested_territory(self, ct_id: str, eager: bool = False) -> ContestedTerritoryEvent:
         """Fetch a specific Contested Territory event by its ID.
 
         .. note::
@@ -101,7 +103,10 @@ class AsyncClient:
 
         :raise ~bloonspy.exceptions.NotFound: If no CT with that ID is found.
         """
-        return ContestedTerritoryEvent(ct_id, eager=eager)
+        ct = ContestedTerritoryEvent(ct_id, async_client=self.__aclient)
+        if eager:
+            await ct.load_event()
+        return ct
 
     @staticmethod
     def get_team(team_id: str) -> Team:
@@ -117,7 +122,7 @@ class AsyncClient:
         """
         return Team(team_id, eager=True)
 
-    async def races(self) -> List[Race]:
+    async def races(self) -> list[Race]:
         """Get a list of Race events.
 
         .. note::
@@ -129,7 +134,11 @@ class AsyncClient:
         races_data = await aget(self.__aclient, "/btd6/races")
         race_list = []
         for race in races_data:
-            race_list.append(Race(race["id"], race_json=race))
+            race_list.append(Race(
+                race["id"],
+                race_json=race,
+                async_client=self.__aclient,
+            ))
         return race_list
 
     @staticmethod
@@ -154,12 +163,16 @@ class AsyncClient:
         """
         return Race(race_id, eager=eager)
 
-    async def bosses(self) -> List[BossEvent]:
+    async def bosses(self) -> list[BossEvent]:
         """Get a list of Boss events."""
         bosses_data = await aget(self.__aclient, "/btd6/bosses")
         boss_list = []
         for boss in bosses_data:
-            boss_list.append(BossEvent(boss["id"], event_json=boss))
+            boss_list.append(BossEvent(
+                boss["id"],
+                event_json=boss,
+                async_client=self.__aclient,
+            ))
         return boss_list
 
     @staticmethod
@@ -184,7 +197,13 @@ class AsyncClient:
         """
         return BossEvent(boss_id, eager=eager)
 
-    async def challenges(self, challenge_filter: ChallengeFilter, pages: int = 1, start_from_page: int = 1) -> List[Challenge]:
+    async def challenges(
+            self,
+            challenge_filter:
+            ChallengeFilter,
+            pages: int = 1,
+            start_from_page: int = 1
+    ) -> list[Challenge]:
         """Get a list of challenges given a specific filter.
 
         .. note::
@@ -200,7 +219,7 @@ class AsyncClient:
         :type start_from_page: int
 
         :return: A list of challenges (lazy loaded).
-        :rtype: List[:class:`bloonspy.model.btd6.Challenge`]
+        :rtype: list[:class:`bloonspy.model.btd6.Challenge`]
         """
 
         challenge_list = []
@@ -277,7 +296,12 @@ class AsyncClient:
         """
         return CustomMap(map_id, eager=True)
 
-    async def custom_maps(self, custom_map_fliter: CustomMapFilter, pages: int = 1, start_from_page: int = 1) -> List[CustomMap]:
+    async def custom_maps(
+            self,
+            custom_map_fliter: CustomMapFilter,
+            pages: int = 1,
+            start_from_page: int = 1
+    ) -> list[CustomMap]:
         """Get a list of challenges given a specific filter.
 
         .. note::
@@ -293,7 +317,7 @@ class AsyncClient:
         :type start_from_page: int
 
         :return: A list of custom maps (lazy loaded).
-        :rtype: List[:class:`bloonspy.model.btd6.CustomMap`]
+        :rtype: list[:class:`bloonspy.model.btd6.CustomMap`]
         """
 
         custom_map_list = []
@@ -315,7 +339,12 @@ class AsyncClient:
 
         for page in custom_map_pages:
             for cmap in page:
-                custom_map_list.append(CustomMap(cmap["id"], name=cmap["name"], created_at=cmap["createdAt"],
-                                                 creator_id=cmap["creator"].split("/")[-1]))
+                custom_map_list.append(CustomMap(
+                    cmap["id"],
+                    name=cmap["name"],
+                    created_at=cmap["createdAt"],
+                    creator_id=cmap["creator"].split("/")[-1],
+                    async_client=self.__aclient,
+                ))
 
         return custom_map_list

--- a/bloonspy/AsyncClient.py
+++ b/bloonspy/AsyncClient.py
@@ -203,8 +203,7 @@ class AsyncClient:
 
     async def challenges(
             self,
-            challenge_filter:
-            ChallengeFilter,
+            challenge_filter: ChallengeFilter,
             pages: int = 1,
             start_from_page: int = 1
     ) -> list[Challenge]:
@@ -258,8 +257,7 @@ class AsyncClient:
 
         return challenge_list
 
-    @staticmethod
-    def get_challenge(challenge_id: str) -> Challenge:
+    async def get_challenge(self, challenge_id: str) -> Challenge:
         """Fetch a specific challenge by its ID.
 
         :param challenge_id: The challenge ID.
@@ -270,7 +268,9 @@ class AsyncClient:
 
         :raise ~bloonspy.exceptions.NotFound: If no challenge with the given ID is found.
         """
-        return Challenge(challenge_id, eager=True)
+        chal = Challenge(challenge_id, async_client=self.__aclient)
+        await chal.load_resource()
+        return chal
 
     @staticmethod
     def get_user(identifier: str) -> User:

--- a/bloonspy/AsyncClient.py
+++ b/bloonspy/AsyncClient.py
@@ -141,8 +141,7 @@ class AsyncClient:
             ))
         return race_list
 
-    @staticmethod
-    def get_race(race_id: str, eager: bool = False) -> Race:
+    async def get_race(self, race_id: str, eager: bool = False) -> Race:
         """Fetch a specific Race by its ID.
 
         .. note::
@@ -161,7 +160,10 @@ class AsyncClient:
 
         :raise ~bloonspy.exceptions.NotFound: If no race with that ID is found.
         """
-        return Race(race_id, eager=eager)
+        race = Race(race_id, async_client=self.__aclient)
+        if eager:
+            await race.load_resource()
+        return race
 
     async def bosses(self) -> list[BossEvent]:
         """Get a list of Boss events."""

--- a/bloonspy/AsyncClient.py
+++ b/bloonspy/AsyncClient.py
@@ -108,8 +108,7 @@ class AsyncClient:
             await ct.load_event()
         return ct
 
-    @staticmethod
-    def get_team(team_id: str) -> Team:
+    async def get_team(self, team_id: str) -> Team:
         """Fetch a specific team by its ID.
 
         :param team_id: The ID of the team.
@@ -120,7 +119,9 @@ class AsyncClient:
 
         :raise ~bloonspy.exceptions.NotFound: If no team with that ID is found.
         """
-        return Team(team_id, eager=True)
+        tm = Team(team_id, async_client=self.__aclient)
+        await tm.load_resource()
+        return tm
 
     async def races(self) -> list[Race]:
         """Get a list of Race events.
@@ -272,8 +273,7 @@ class AsyncClient:
         await chal.load_resource()
         return chal
 
-    @staticmethod
-    def get_user(identifier: str) -> User:
+    async def get_user(self, identifier: str) -> User:
         """Fetch a specific user by an identifier.
 
         :param identifier: The user ID, or its OAK.
@@ -284,13 +284,14 @@ class AsyncClient:
 
         :raise ~bloonspy.exceptions.NotFound: If no user with the given ID/OAK is found.
         """
-        return User(identifier, eager=True)
+        usr = User(identifier, async_client=self.__aclient)
+        await usr.load_resource()
+        return usr
 
-    @staticmethod
-    def get_custom_map(map_id: str) -> CustomMap:
+    async def get_custom_map(self, map_id: str) -> CustomMap:
         """Fetch a specific custom map by its ID.
 
-        :param map_id: The challenge ID.
+        :param map_id: The map code.
         :type map_id: str
 
         :return: The found map.
@@ -298,7 +299,9 @@ class AsyncClient:
 
         :raise ~bloonspy.exceptions.NotFound: If no custom map with the given ID is found.
         """
-        return CustomMap(map_id, eager=True)
+        cmap = CustomMap(map_id, async_client=self.__aclient)
+        await cmap.load_resource()
+        return cmap
 
     async def custom_maps(
             self,

--- a/bloonspy/AsyncClient.py
+++ b/bloonspy/AsyncClient.py
@@ -19,6 +19,11 @@ class AsyncClient:
        **raise ~bloonspy.exceptions.NotLoaded instead of loading it.** Either eager
        load it or call the load methods beforehand.
 
+    .. note::
+       When accessing objects through `AsyncClient`, the API is exactly the same. However,
+       properties do not have to be awaited. Only methods do.
+       **If you have to use parenthesis, you should await.**
+
     :param open_access_key: Your OAK for the Ninja Kiwi Open Data API.
     :type open_access_key: str
     :param aiohttp_client: An aiohttp Client. Will create one if not provided.

--- a/bloonspy/AsyncClient.py
+++ b/bloonspy/AsyncClient.py
@@ -177,8 +177,7 @@ class AsyncClient:
             ))
         return boss_list
 
-    @staticmethod
-    def get_boss(boss_id: str, eager: bool = False) -> BossEvent:
+    async def get_boss(self, boss_id: str, eager: bool = False) -> BossEvent:
         """Fetch a specific Boss event by its ID.
 
         .. note::
@@ -197,7 +196,10 @@ class AsyncClient:
 
         :raise ~bloonspy.exceptions.NotFound: If no boss event with that ID is found.
         """
-        return BossEvent(boss_id, eager=eager)
+        boss = BossEvent(boss_id, async_client=self.__aclient)
+        if eager:
+            await boss.load_event()
+        return boss
 
     async def challenges(
             self,

--- a/bloonspy/Client.py
+++ b/bloonspy/Client.py
@@ -238,7 +238,7 @@ class Client:
     def get_custom_map(map_id: str) -> CustomMap:
         """Fetch a specific custom map by its ID.
 
-        :param map_id: The challenge ID.
+        :param map_id: The map code.
         :type map_id: str
 
         :return: The found map.

--- a/bloonspy/__init__.py
+++ b/bloonspy/__init__.py
@@ -2,5 +2,5 @@ from .Client import *
 from .model import btd6
 from .utils import Infinity
 
-__version__ = "0.8.1"
-__author__ = "TheSartorsss"
+__version__ = "0.9.0"
+__author__ = "SartoRiccardo"

--- a/bloonspy/__init__.py
+++ b/bloonspy/__init__.py
@@ -3,5 +3,5 @@ from .AsyncClient import AsyncClient
 from .model import btd6
 from .utils import Infinity
 
-__version__ = "0.9.0"
+__version__ = "0.9.1"
 __author__ = "SartoRiccardo"

--- a/bloonspy/__init__.py
+++ b/bloonspy/__init__.py
@@ -1,4 +1,5 @@
 from .Client import *
+from .AsyncClient import AsyncClient
 from .model import btd6
 from .utils import Infinity
 

--- a/bloonspy/exceptions.py
+++ b/bloonspy/exceptions.py
@@ -38,3 +38,11 @@ class Forbidden(BloonsException):
     """
     pass
 
+
+class NotLoaded(BloonsException):
+    """
+    *New in 0.9.0*
+
+    You attempted to access an unloaded property in a lazy-loaded resource in an
+    asynchronous environment.
+    """

--- a/bloonspy/model/Event.py
+++ b/bloonspy/model/Event.py
@@ -1,9 +1,12 @@
 from typing import Dict, Any, List
 from datetime import datetime
+import aiohttp
 from ..utils.dictionaries import has_all_keys
 from ..utils.decorators import fetch_property, exception_handler
 from ..utils.api import get
+from ..utils.asyncapi import aget
 from ..exceptions import NotFound
+from typing import Awaitable
 
 
 class Event:
@@ -20,14 +23,21 @@ class Event:
     event_dict_keys: List[str] = ["name", "start", "end"]
     event_name: str = "event"
 
-    def __init__(self, event_id: str, eager: bool = False, event_json: Dict[str, Any] = None):
+    def __init__(
+            self,
+            event_id: str,
+            eager: bool = False,
+            event_json: Dict[str, Any] = None,
+            async_client: aiohttp.ClientSession | None = None
+    ):
         self._id = event_id
         self._data = {}
         self._event_loaded = False
+        self._async_client = async_client
 
         if event_json and has_all_keys(event_json, self.event_dict_keys):
             self._parse_event(event_json)
-        if eager and not self._event_loaded:
+        if eager and not self._event_loaded and self._async_client is None:
             self.load_event()
 
     def handle_exceptions(self, exception: Exception) -> None:
@@ -40,7 +50,7 @@ class Event:
         raise exception
 
     @exception_handler(handle_exceptions)
-    def load_event(self, only_if_unloaded: bool = True) -> None:
+    def load_event(self, only_if_unloaded: bool = True) -> Awaitable[None] | None:
         """Load the event.
 
         :param only_if_unloaded: Only make an API call if the event is unloaded.
@@ -54,13 +64,20 @@ class Event:
 
         self._event_loaded = False
 
-        event_list = get(self.event_endpoint)
-        for event in event_list:
-            if event["id"] == self._id:
-                self._parse_event(event)
-                return
+        def on_data_fetched(event_list: list[dict]) -> None:
+            for event in event_list:
+                if event["id"] == self._id:
+                    self._parse_event(event)
+                    return
+            raise NotFound(f"No {self.event_name} with that ID exists")
 
-        raise NotFound(f"No {self.event_name} with that ID exists")
+        async def async_load_event():
+            event_list = await aget(self._async_client, self.event_endpoint)
+            on_data_fetched(event_list)
+
+        if self._async_client:
+            return async_load_event()
+        on_data_fetched(get(self.event_endpoint))
 
     def _parse_event(self, data: Dict[str, Any]) -> None:
         self._data["name"] = data["name"]
@@ -96,6 +113,10 @@ class Event:
     def end(self) -> datetime:
         """When the event ends."""
         return self._data["end"]
+
+    @property
+    def loaded(self):
+        return self._event_loaded
 
     def __eq__(self, other):
         return isinstance(other, type(self)) and other.id == self.id

--- a/bloonspy/model/Loadable.py
+++ b/bloonspy/model/Loadable.py
@@ -1,6 +1,9 @@
-from typing import Dict, Any
+from typing import Awaitable, Any
+import aiohttp
 from ..utils.api import get
+from ..utils.asyncapi import aget
 from ..utils.decorators import exception_handler
+from ..exceptions import NotLoaded
 
 
 class Loadable:
@@ -14,11 +17,17 @@ class Loadable:
     """
     endpoint = "{}"
 
-    def __init__(self, resource_id: str, eager: bool = False):
+    def __init__(
+            self,
+            resource_id: str,
+            eager: bool = False,
+            async_client: aiohttp.ClientSession | None = None,
+    ):
         self._id = resource_id
         self._data = {}
         self._loaded = False
-        if eager:
+        self._async_client = async_client
+        if eager and self._async_client is None:
             self.load_resource()
 
     def handle_exceptions(self, exception: Exception) -> None:
@@ -28,7 +37,7 @@ class Loadable:
         raise exception
 
     @exception_handler(handle_exceptions)
-    def load_resource(self, only_if_unloaded: bool = True) -> None:
+    def load_resource(self, only_if_unloaded: bool = True) -> Awaitable[None] | None:
         """Load the resource.
 
         :param only_if_unloaded: Only make an API call if the resource is unloaded.
@@ -40,8 +49,16 @@ class Loadable:
         if self._loaded and only_if_unloaded:
             return
 
-        data = get(self.endpoint.format(self._id))
-        self._parse_json(data)
+        def on_data_load(data) -> None:
+            self._parse_json(data)
+
+        async def async_load() -> None:
+            data = await aget(self._async_client, self.endpoint.format(self._id))
+            on_data_load(data)
+
+        if self._async_client:
+            return async_load()
+        on_data_load(get(self.endpoint.format(self._id)))
 
     @staticmethod
     def _should_load_property(key_name: str) -> callable:
@@ -49,7 +66,7 @@ class Loadable:
             return key_name not in self._data
         return _inner
 
-    def _parse_json(self, raw_user: Dict[str, Any]) -> None:
+    def _parse_json(self, raw_user: dict[str, Any]) -> None:
         self._loaded = True
 
     @property

--- a/bloonspy/model/btd6/Challenge.py
+++ b/bloonspy/model/btd6/Challenge.py
@@ -43,10 +43,16 @@ class Challenge(Loadable):
 
     endpoint = "/btd6/challenges/challenge/{}"
 
-    def __init__(self, challenge_id: str, eager: bool = False, name: str = None, created_at: int = None,
-                 creator_id: str = None, raw_challenge: Dict[str, Any] = None):
+    def __init__(
+            self,
+            challenge_id: str,
+            name: str = None, created_at: int = None,
+            creator_id: str = None,
+            raw_challenge: Dict[str, Any] = None,
+            **kwargs,
+    ):
         """Constructor method."""
-        super().__init__(challenge_id, eager=eager)
+        super().__init__(challenge_id, **kwargs)
         if raw_challenge:
             self._parse_json(raw_challenge)
         if name:

--- a/bloonspy/model/btd6/Challenge.py
+++ b/bloonspy/model/btd6/Challenge.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass, field
 from enum import Enum
 from datetime import datetime
-from typing import List, Dict, Union, Any
+from typing import Awaitable, Any
 from ...utils.decorators import fetch_property
 from ...exceptions import NotFound
 from ..GameVersion import GameVersion
@@ -48,7 +48,7 @@ class Challenge(Loadable):
             challenge_id: str,
             name: str = None, created_at: int = None,
             creator_id: str = None,
-            raw_challenge: Dict[str, Any] = None,
+            raw_challenge: dict[str, Any] = None,
             **kwargs,
     ):
         """Constructor method."""
@@ -67,7 +67,7 @@ class Challenge(Loadable):
         if error_msg == "No challenge with that ID exists":
             raise NotFound(error_msg)
 
-    def _parse_json(self, raw_challenge: Dict[str, Any]) -> None:
+    def _parse_json(self, raw_challenge: dict[str, Any]) -> None:
         self._loaded = False
 
         copy_keys = [
@@ -179,7 +179,7 @@ class Challenge(Loadable):
         return self._data["creatorId"]
 
     @fetch_property(Loadable.load_resource, should_load=Loadable._should_load_property("creatorId"))
-    def creator(self) -> User or None:
+    def creator(self) -> Awaitable[User | None] | User | None:
         """Fetch the creator of the challenge.
 
         .. warning::
@@ -189,9 +189,19 @@ class Challenge(Loadable):
         :return: The creator of the challenge of `None` if there isn't one.
         :rtype: User or None
         """
+        async def async_creator() -> User | None:
+            if self.creator_id is None:
+                return None
+            usr = User(self.creator_id, async_client=self._async_client)
+            await usr.load_resource()
+            return usr
+
+        if self._async_client:
+            return async_creator()
+
         if self.creator_id is None:
             return None
-        return User(self.creator_id, eager=True)
+        return User(self.creator_id, eager=True, async_client=self._async_client)
 
     @property
     @fetch_property(Loadable.load_resource)
@@ -335,13 +345,13 @@ class Challenge(Loadable):
 
     @property
     @fetch_property(Loadable.load_resource)
-    def least_cash_used(self) -> Union[int, Infinity]:
+    def least_cash_used(self) -> int | Infinity:
         """Least Cash restriction on the challenge. If there's none, it's :class:`Infinity`."""
         return self._data["leastCash"]
 
     @property
     @fetch_property(Loadable.load_resource)
-    def least_tiers_used(self) -> Union[int, Infinity]:
+    def least_tiers_used(self) -> int | Infinity:
         """Least Tiers restriction on the challenge. If there's none, it's :class:`Infinity`."""
         return self._data["leastTiers"]
 
@@ -353,24 +363,24 @@ class Challenge(Loadable):
 
     @property
     @fetch_property(Loadable.load_resource)
-    def round_sets(self) -> List[str]:
+    def round_sets(self) -> list[str]:
         """Names of the round sets of the challenge."""
         return self._data["roundSets"]
 
     @property
     @fetch_property(Loadable.load_resource)
-    def powers(self) -> Dict[Power, Union[int, Infinity]]:
+    def powers(self) -> dict[Power, int | Infinity]:
         """The powers allowed for the challenge, and how many you can use of each."""
         return self._data["powers"]
 
     @property
     @fetch_property(Loadable.load_resource)
-    def modifiers(self) -> Dict[ChallengeModifier, float]:
+    def modifiers(self) -> dict[ChallengeModifier, float]:
         """Challenge modifiers, such as bloon speeds and health."""
         return self._data["modifiers"]
 
     @property
     @fetch_property(Loadable.load_resource)
-    def towers(self) -> Dict[Tower, Restriction]:
+    def towers(self) -> dict[Tower, Restriction]:
         """Tower and Hero restrictions on the challenge."""
         return self._data["towers"]

--- a/bloonspy/model/btd6/ContestedTerritory.py
+++ b/bloonspy/model/btd6/ContestedTerritory.py
@@ -183,7 +183,7 @@ class ContestedTerritoryEvent(Event):
     event_endpoint = "/btd6/ct"
     lb_endpoint_player = "/btd6/ct/{}/leaderboard/player"
     lb_endpoint_team = "/btd6/ct/{}/leaderboard/team"
-    event_dict_keys = ["name", "start", "end", "totalScores_player", "totalScores_team"]
+    event_dict_keys = ["start", "end", "totalScores_player", "totalScores_team"]
     event_name = "CT"
 
     def _parse_event(self, data: dict[str, Any]) -> None:
@@ -198,20 +198,20 @@ class ContestedTerritoryEvent(Event):
         return f"Contested Territory #{self.event_number}"
 
     @property
-    @fetch_property(Event.load_event, should_load=Event._should_load_property)
+    @fetch_property(Event.load_event, should_load=Event._should_load_property("start"))
     def event_number(self) -> int:
         """Number of the event."""
         first_event_start = datetime.strptime('2022-08-09 22', '%Y-%m-%d %H')
         return int((self.start-first_event_start).days/14) + 1
 
     @property
-    @fetch_property(Event.load_event, should_load=Event._should_load_property)
+    @fetch_property(Event.load_event, should_load=Event._should_load_property("totalScores_player"))
     def total_scores_player(self) -> int:
         """Number of players who participated in the event."""
         return self._data["totalScores_player"]
 
     @property
-    @fetch_property(Event.load_event, should_load=Event._should_load_property)
+    @fetch_property(Event.load_event, should_load=Event._should_load_property("totalScores_team"))
     def total_scores_team(self) -> int:
         """Number of teams who participated in the event."""
         return self._data["totalScores_team"]

--- a/bloonspy/model/btd6/CustomMap.py
+++ b/bloonspy/model/btd6/CustomMap.py
@@ -16,10 +16,17 @@ class CustomMap(Loadable):
 
     endpoint = "/btd6/maps/map/{}"
 
-    def __init__(self, map_id: str, eager: bool = False, created_at: int = None, name: str = None,
-                 creator_id: str = None, raw_map: dict = None):
+    def __init__(
+            self,
+            map_id: str,
+            created_at: int = None,
+            name: str = None,
+            creator_id: str = None,
+            raw_map: dict = None,
+            **kwargs,
+    ):
         """Constructor method."""
-        super().__init__(map_id, eager=eager)
+        super().__init__(map_id, **kwargs)
         if raw_map:
             self._parse_json(raw_map)
         if name:

--- a/bloonspy/model/btd6/CustomMap.py
+++ b/bloonspy/model/btd6/CustomMap.py
@@ -38,7 +38,8 @@ class CustomMap(Loadable):
 
     def _handle_exceptions(self, exception: Exception) -> None:
         error_msg = str(exception)
-        if error_msg.lower() == "no map with that id exists":
+        if error_msg.lower() == "no map with that id exists" or \
+                error_msg.lower() == "invalid map id":
             raise NotFound(error_msg)
 
     def _parse_json(self, raw_map: dict) -> None:

--- a/bloonspy/model/btd6/Race.py
+++ b/bloonspy/model/btd6/Race.py
@@ -163,7 +163,7 @@ class Race(Challenge):
         def on_pages_fetched(responses) -> list[RacePlayer]:
             race_players = []
             for page in responses:
-                for player in page.result():
+                for player in page:
                     race_players.append(RacePlayer(
                         player["profile"].split("/")[-1],
                         player["displayName"],

--- a/bloonspy/model/btd6/Race.py
+++ b/bloonspy/model/btd6/Race.py
@@ -1,9 +1,11 @@
+import asyncio
 from datetime import datetime, timedelta
 from concurrent.futures import ThreadPoolExecutor
-from typing import List, Dict, Any
+from typing import Any, Awaitable
 from ...utils.decorators import fetch_property, exception_handler
 from ...utils.dictionaries import has_all_keys
 from ...utils.api import get, get_lb_page
+from ...utils.asyncapi import aget, aget_lb_page
 from ...exceptions import NotFound
 from .Challenge import Challenge
 from .Score import Score
@@ -18,7 +20,7 @@ class RacePlayer(User):
                  user_id: str,
                  name: str,
                  score: int,
-                 score_parts: List[Dict[str, Any]],
+                 score_parts: list[dict[str, Any]],
                  submission_time: int,
                  **kwargs):
         super().__init__(user_id, **kwargs)
@@ -38,7 +40,7 @@ class RacePlayer(User):
         return self._score_parts[0] if len(self._score_parts) > 0 else self._score
 
     @property
-    def score_parts(self) -> List[Score]:
+    def score_parts(self) -> list[Score]:
         """The score parts."""
         return self._score_parts
 
@@ -55,16 +57,32 @@ class Race(Challenge):
     event_endpoint = "/btd6/races"
     lb_endpoint = "/btd6/races/{}/leaderboard"
 
-    def __init__(self, race_id: str, eager: bool = False, race_json: Dict[str, Any] = None):
-        super().__init__(race_id, eager=eager)
+    def __init__(
+            self,
+            race_id: str,
+            eager: bool = False,
+            race_json: dict[str, Any] = None,
+            **kwargs,
+    ):
+        super().__init__(race_id, eager=eager, **kwargs)
         self._start = datetime.fromtimestamp(0)
         self._end = datetime.fromtimestamp(0)
         self._total_scores = 0
         self._race_loaded = eager
         if race_json and has_all_keys(race_json, ["name", "start", "end", "totalScores"]):
             self._parse_race(race_json)
-        if eager and not self._race_loaded:
+        if eager and not self._race_loaded and self._async_client is None:
             self._load_race()
+
+    def load_resource(self, only_if_unloaded: bool = True) -> Awaitable[None] | None:
+        async def async_load():
+            await super().load_resource(only_if_unloaded)
+            await self._load_race(only_if_unloaded)
+
+        if self._async_client:
+            return async_load()
+        super().load_resource(only_if_unloaded)
+        self._load_race(only_if_unloaded)
 
     def _handle_exceptions(self, exception: Exception) -> None:
         error_msg = str(exception)
@@ -72,21 +90,27 @@ class Race(Challenge):
             raise NotFound(error_msg)
 
     @exception_handler(Challenge.handle_exceptions)
-    def _load_race(self, only_if_unloaded: bool = True) -> None:
+    def _load_race(self, only_if_unloaded: bool = True) -> Awaitable[None] | None:
         if self._race_loaded and only_if_unloaded:
             return
 
+        def on_data_load(data) -> None:
+            for race in data:
+                if race["id"] == self._id:
+                    self._parse_race(race)
+                    return
+            raise NotFound("No Race with that ID exists")
+
+        async def async_load() -> None:
+            data = await aget(self._async_client, self.event_endpoint)
+            on_data_load(data)
+
         self._race_loaded = False
+        if self._async_client:
+            return async_load()
+        on_data_load(get(self.event_endpoint))
 
-        race_list = get(self.event_endpoint)
-        for race in race_list:
-            if race["id"] == self._id:
-                self._parse_race(race)
-                return
-
-        raise NotFound("No Race with that ID exists")
-
-    def _parse_race(self, data: Dict[str, Any]) -> None:
+    def _parse_race(self, data: dict[str, Any]) -> None:
         self._data["name"] = data["name"]
         self._start = datetime.fromtimestamp(data["start"]/1000)
         self._end = datetime.fromtimestamp(data["end"]/1000)
@@ -118,7 +142,7 @@ class Race(Challenge):
         return self._total_scores
 
     @exception_handler(Challenge.handle_exceptions)
-    def leaderboard(self, pages: int = 1, start_from_page: int = 1) -> List[RacePlayer]:
+    def leaderboard(self, pages: int = 1, start_from_page: int = 1) -> list[RacePlayer] | Awaitable[list[RacePlayer]]:
         """Get a page of the leaderboard for this event.
 
         .. note::
@@ -132,24 +156,37 @@ class Race(Challenge):
         :type start_from_page: int
 
         :return: A list of players in the leaderboard.
-        :rtype: List[:class:`~bloonspy.model.btd6.RacePlayer`]
+        :rtype: list[:class:`~bloonspy.model.btd6.RacePlayer`]
 
         :raise ~bloonspy.exceptions.NotFound: If the race doesn't exist or is expired.
         """
+        def on_pages_fetched(responses) -> list[RacePlayer]:
+            race_players = []
+            for page in responses:
+                for player in page.result():
+                    race_players.append(RacePlayer(
+                        player["profile"].split("/")[-1],
+                        player["displayName"],
+                        player["score"],
+                        player["scoreParts"],
+                        player["submissionTime"],
+                        async_client=self._async_client,
+                    ))
+            return race_players
+
+        async def async_get_leaderboard() -> list[RacePlayer]:
+            results = await asyncio.gather(*[
+                aget_lb_page(self._async_client, self.lb_endpoint.format(self._id), page_num)
+                for page_num in range(start_from_page, start_from_page + pages)
+            ])
+            return on_pages_fetched(results)
+
+        if self._async_client:
+            return async_get_leaderboard()
+
         futures = []
         with ThreadPoolExecutor(max_workers=10) as executor:
             for page_num in range(start_from_page, start_from_page + pages):
                 futures.append(executor.submit(get_lb_page, self.lb_endpoint.format(self._id), page_num))
+        return on_pages_fetched([page.result() for page in futures])
 
-        race_players = []
-        for page in futures:
-            for player in page.result():
-                race_players.append(RacePlayer(
-                    player["profile"].split("/")[-1],
-                    player["displayName"],
-                    player["score"],
-                    player["scoreParts"],
-                    player["submissionTime"]
-                ))
-
-        return race_players

--- a/bloonspy/model/btd6/User.py
+++ b/bloonspy/model/btd6/User.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Dict, Any
+from typing import Awaitable, Any
 from ...exceptions import NotFound, Forbidden
 from ...utils.decorators import fetch_property
 from ...utils.dictionaries import rename_keys
@@ -66,7 +66,7 @@ class User(Loadable):
         if error_msg == "Invalid user ID / Player Does not play this game":
             raise NotFound(error_msg)
 
-    def _parse_json(self, raw_user: Dict[str, Any]) -> None:
+    def _parse_json(self, raw_user: dict[str, Any]) -> None:
         self._loaded = False
 
         copy_keys = ["displayName", "rank", "veteranRank", "achievements", "followers"]
@@ -268,11 +268,11 @@ class User(Loadable):
 
     @property
     @fetch_property(Loadable.load_resource)
-    def heroes_placed(self) -> Dict[Tower, int]:
+    def heroes_placed(self) -> dict[Tower, int]:
         """Number of times each hero has been placed."""
         return self._data["heroes_placed"]
 
-    def get_progress(self) -> UserSave:
+    def get_progress(self) -> Awaitable[UserSave] | UserSave:
         """
         *New in 0.5.0*
 
@@ -290,7 +290,7 @@ class User(Loadable):
         """
         if not self.has_oak():
             raise Forbidden()
-        return UserSave.fetch(self.id)
+        return UserSave.fetch(self.id, self._async_client)
 
     def has_oak(self) -> bool:
         """

--- a/bloonspy/model/btd6/UserSave.py
+++ b/bloonspy/model/btd6/UserSave.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+import aiohttp
 from ..GameVersion import GameVersion
 from .Tower import Tower, HeroSkin
 from .Power import Power, PowerAmount
@@ -8,8 +9,9 @@ from .Rewards import InstaMonkey
 from .Progress import MonkeyKnowledge, Upgrade, Achievement
 from .Map import MapProgress, Map, GamemodeCompletionData
 from .Cosmetics import TrophyStoreItemStatus
-from typing import Any
+from typing import Any, Awaitable
 from ...utils.api import get
+from ...utils.asyncapi import aget
 from ...exceptions import NotFound
 from ...utils.decorators import exception_handler
 
@@ -72,19 +74,26 @@ class UserSave:
 
     @staticmethod
     @exception_handler(_handle_exception)
-    def fetch(oak: str) -> "UserSave":
+    def fetch(oak: str, client: aiohttp.ClientSession | None = None) -> Awaitable["UserSave"] | "UserSave":
         """
         Get an UserSave object through an OAK.
 
         :param oak: The OAK used to get the save of.
         :type oak: str
+        :param client: An aiohttp client session, if working in an asynchronous environment.
+        :type client: aiohttp.ClientSession
         :return: The UserSave belonging to the User who owns the OAK.
         :rtype: ~bloonspy.model.btd6.UserSave
 
         :raises bloonspy.exceptions.NotFound: If the player is not found.
         """
-        data = get("/btd6/save/{}".format(oak))
-        return UserSave._parse_json(data)
+        async def async_fetch():
+            return UserSave._parse_json(
+                await aget(client, "/btd6/save/{}".format(oak))
+            )
+        if client:
+            return async_fetch()
+        return UserSave._parse_json(get("/btd6/save/{}".format(oak)))
 
     @staticmethod
     def _parse_json(data: dict[str, Any]) -> "UserSave":

--- a/bloonspy/model/btd6/UserSave.py
+++ b/bloonspy/model/btd6/UserSave.py
@@ -68,7 +68,8 @@ class UserSave:
 
     def _handle_exception(self, exception: Exception) -> None:
         error_msg = str(exception)
-        if error_msg == "Invalid user ID / Player Does not play this game":
+        if error_msg == "Invalid user ID / Player Does not play this game" or \
+                error_msg == "This endpoint requires an OAK id. An invalid oak ID was given or the player does not play this game":
             raise NotFound(error_msg)
         raise exception
 

--- a/bloonspy/utils/api.py
+++ b/bloonspy/utils/api.py
@@ -5,6 +5,7 @@ import random
 from typing import Dict, Any, List, Union
 from ..exceptions import BloonsException, UnderMaintenance
 import sys
+import http
 
 
 API_URL = "https://data.ninjakiwi.com"
@@ -32,27 +33,15 @@ def get(endpoint: str, params: Dict[str, Any] = None) -> Union[List[Dict[str, An
             request_lock.join()
 
         resp = requests.get(API_URL + endpoint, params=params, headers={"User-Agent": "bloonspy Python Library"})
-        if resp.status_code >= 500:
+        check_response(resp)
+
+        if resp.status_code == 403 and "Retry-After" in resp.headers:
+            retry_after = int(resp.headers["Retry-After"]) + random.random() * 3
             if "unittest" in sys.modules.keys():
-                print(resp.content)
-                print(resp.headers)
-
-            if resp.status_code == 525:
-                raise UnderMaintenance("Server is under maintenance")
-
-            raise BloonsException("Server error occurred")
-        if resp.status_code >= 400:
-            if resp.status_code == 403 and "Retry-After" in resp.headers:
-                retry_after = int(resp.headers["Retry-After"]) + random.random()*3
-                if "unittest" in sys.modules.keys():
-                    print(f"Hit rate limit. Retry after {retry_after}s.")
-                request_lock = threading.Thread(target=lock_requests, args=(retry_after, ))
-                request_lock.start()
-                continue
-
-            raise BloonsException("Bad request")
-        if "application/json" not in resp.headers.get("content-type").lower():
-            raise BloonsException("Response is not JSON")
+                print(f"Hit rate limit. Retry after {retry_after}s.")
+            request_lock = threading.Thread(target=lock_requests, args=(retry_after,))
+            request_lock.start()
+            continue
 
         data = resp.json()
         if not data["success"]:
@@ -68,3 +57,19 @@ def get_lb_page(endpoint: str, page_num: int):
         if str(exc) == "No Scores Available":
             return []
         raise exc
+
+
+def check_response(resp) -> None:
+    if resp.status_code >= 500:
+        if "unittest" in sys.modules.keys():
+            print(resp.content)
+            print(resp.headers)
+
+        if resp.status_code == 525:
+            raise UnderMaintenance("Server is under maintenance")
+
+        raise BloonsException("Server error occurred")
+    if resp.status_code >= 400 and not resp.status_code == http.HTTPStatus.FORBIDDEN:
+        raise BloonsException("Bad request")
+    if "application/json" not in resp.headers.get("content-type").lower():
+        raise BloonsException("Response is not JSON")

--- a/bloonspy/utils/asyncapi.py
+++ b/bloonspy/utils/asyncapi.py
@@ -1,4 +1,5 @@
 import asyncio
+import aiohttp
 import http
 import random
 from typing import Dict, Any
@@ -30,9 +31,10 @@ async def aget(client: aiohttp.ClientSession, endpoint: str, params: Dict[str, A
         while requests_locked:
             await asyncio.sleep(random.random()*3+1)
 
-        with client.get(API_URL + endpoint, params=params, headers={"User-Agent": "bloonspy Python Library"}) as resp:
-            check_response(resp)
-            if resp.status_code == http.HTTPStatus.FORBIDDEN and "Retry-After" in resp.headers:
+        print(str(client) + "\n\n\n\n\n")
+        async with client.get(API_URL + endpoint, params=params, headers={"User-Agent": "bloonspy Python Library"}) as resp:
+            check_response(resp.status, resp.headers.get("content-type").lower())
+            if resp.status == http.HTTPStatus.FORBIDDEN and "Retry-After" in resp.headers:
                 retry_after = int(resp.headers["Retry-After"]) + random.random()*3
                 if "unittest" in sys.modules.keys():
                     print(f"Hit rate limit. Retry after {retry_after}s.")

--- a/bloonspy/utils/asyncapi.py
+++ b/bloonspy/utils/asyncapi.py
@@ -21,7 +21,7 @@ async def lock_requests(lock_time: float) -> None:
 async def aget(client: aiohttp.ClientSession, endpoint: str, params: Dict[str, Any] = None) -> list[dict[str, Any]] | dict[str, Any]:
     global requests_locked
 
-    if "unittest" in sys.modules.keys():
+    if "pytest" in sys.modules.keys():
         print(f"GET {endpoint}, {params=}")
 
     if params is None:
@@ -31,7 +31,6 @@ async def aget(client: aiohttp.ClientSession, endpoint: str, params: Dict[str, A
         while requests_locked:
             await asyncio.sleep(random.random()*3+1)
 
-        print(str(client) + "\n\n\n\n\n")
         async with client.get(API_URL + endpoint, params=params, headers={"User-Agent": "bloonspy Python Library"}) as resp:
             check_response(resp.status, resp.headers.get("content-type").lower())
             if resp.status == http.HTTPStatus.FORBIDDEN and "Retry-After" in resp.headers:

--- a/bloonspy/utils/asyncapi.py
+++ b/bloonspy/utils/asyncapi.py
@@ -46,9 +46,9 @@ async def aget(client: aiohttp.ClientSession, endpoint: str, params: Dict[str, A
             return data["body"]
 
 
-async def get_lb_page(endpoint: str, page_num: int):
+async def aget_lb_page(client: aiohttp.ClientSession, endpoint: str, page_num: int):
     try:
-        return get(endpoint, params={"page": page_num})
+        return await aget(client, endpoint, params={"page": page_num})
     except BloonsException as exc:
         if str(exc) == "No Scores Available":
             return []

--- a/bloonspy/utils/asyncapi.py
+++ b/bloonspy/utils/asyncapi.py
@@ -1,0 +1,54 @@
+import asyncio
+import http
+import random
+from typing import Dict, Any
+from ..exceptions import BloonsException
+import sys
+from .api import API_URL, check_response
+
+
+requests_locked = False
+
+
+async def lock_requests(lock_time: float) -> None:
+    global requests_locked
+    requests_locked = True
+    await asyncio.sleep(lock_time)
+    requests_locked = False
+
+
+async def aget(client: aiohttp.ClientSession, endpoint: str, params: Dict[str, Any] = None) -> list[dict[str, Any]] | dict[str, Any]:
+    global requests_locked
+
+    if "unittest" in sys.modules.keys():
+        print(f"GET {endpoint}, {params=}")
+
+    if params is None:
+        params = {}
+
+    while True:
+        while requests_locked:
+            await asyncio.sleep(random.random()*3+1)
+
+        with client.get(API_URL + endpoint, params=params, headers={"User-Agent": "bloonspy Python Library"}) as resp:
+            check_response(resp)
+            if resp.status_code == http.HTTPStatus.FORBIDDEN and "Retry-After" in resp.headers:
+                retry_after = int(resp.headers["Retry-After"]) + random.random()*3
+                if "unittest" in sys.modules.keys():
+                    print(f"Hit rate limit. Retry after {retry_after}s.")
+
+                continue
+
+            data = await resp.json()
+            if not data["success"]:
+                raise BloonsException(data["error"])
+            return data["body"]
+
+
+async def get_lb_page(endpoint: str, page_num: int):
+    try:
+        return get(endpoint, params={"page": page_num})
+    except BloonsException as exc:
+        if str(exc) == "No Scores Available":
+            return []
+        raise exc

--- a/bloonspy/utils/decorators.py
+++ b/bloonspy/utils/decorators.py
@@ -1,10 +1,13 @@
 from functools import wraps
+from ..exceptions import NotLoaded
 
 
 def fetch_property(loading_func: callable, should_load: callable = None):
     def _decorator(wrapped: callable):
         @wraps(wrapped)
         def wrapper(self, *args, **kwargs):
+            if not self.loaded and self._async_client:
+                raise NotLoaded()
             if should_load is None or should_load(self):
                 loading_func(self)
             return wrapped(self, *args, **kwargs)

--- a/bloonspy/utils/decorators.py
+++ b/bloonspy/utils/decorators.py
@@ -6,9 +6,9 @@ def fetch_property(loading_func: callable, should_load: callable = None):
     def _decorator(wrapped: callable):
         @wraps(wrapped)
         def wrapper(self, *args, **kwargs):
-            if not self.loaded and self._async_client:
-                raise NotLoaded()
             if should_load is None or should_load(self):
+                if not self.loaded and self._async_client:
+                    raise NotLoaded()
                 loading_func(self)
             return wrapped(self, *args, **kwargs)
         return wrapper

--- a/docs/source/pages/api.rst
+++ b/docs/source/pages/api.rst
@@ -11,9 +11,18 @@ Client
 
 This is the class you'll be interfacing with to get data about the games. Most methods are
 static, however you can create an instance with a Ninja Kiwi Open Access Key to gain access
-to more functions.
+to more functions. If you are in an asynchronous envirnoment, you should check out :class:`bloonspy.AsyncClient`.
 
 .. autoclass:: bloonspy.Client
+   :members:
+
+
+AsyncClient
+-----------
+
+Client for asynchronous environments.
+
+.. autoclass:: bloonspy.AsyncClient
    :members:
 
 Model

--- a/docs/source/pages/api.rst
+++ b/docs/source/pages/api.rst
@@ -485,3 +485,9 @@ Forbidden
 
 .. autoclass:: bloonspy.exceptions.Forbidden
    :members:
+
+Forbidden
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: bloonspy.exceptions.NotLoaded
+   :members:

--- a/tests/async/test_boss_leaderboard.py
+++ b/tests/async/test_boss_leaderboard.py
@@ -1,0 +1,56 @@
+from datetime import datetime
+import random
+import aiohttp
+from bloonspy import btd6, AsyncClient
+
+
+class TestBossLeaderboard:
+    async def test_boss_leaderboard(self) -> None:
+        """
+        Test fetching a boss' leaderboard.
+        """
+        async with aiohttp.ClientSession() as session:
+            client = AsyncClient(aiohttp_client=session)
+            bosses = await client.bosses()
+            boss = bosses[1]
+            # Get #51-#100
+            standard_boss = await boss.standard()
+            boss_leaderboard = await standard_boss.leaderboard(pages=2, start_from_page=2)
+
+            assert len(boss_leaderboard) > 0
+            some_player = boss_leaderboard[random.randint(0, len(boss_leaderboard)-1)]
+            assert isinstance(some_player, btd6.BossPlayer), \
+                "Assert if result is BossPlayer"
+
+            check_instance = [
+                ("name", str), ("score", btd6.Score), ("submission_time", datetime)
+            ]
+            for attr_name, attr_type in check_instance:
+                assert isinstance(getattr(some_player, attr_name), attr_type), \
+                    f"Assert if BossPlayer.{attr_name} is {attr_type}"
+
+    async def test_boss_leaderboard_coop(self) -> None:
+        """
+        Test fetching a boss' coop leaderboard.
+        """
+        async with aiohttp.ClientSession() as session:
+            client = AsyncClient(aiohttp_client=session)
+            bosses = await client.bosses()
+            boss = bosses[1]
+            standard_boss = await boss.standard()
+            assert isinstance(standard_boss, btd6.Boss), \
+                "Assert BossEvent.standard() is a Boss"
+            boss_leaderboard_coop = await standard_boss.leaderboard(pages=3, team_size=3)
+
+            check_instance = [
+                ("score", btd6.Score), ("submission_time", datetime), ("is_fully_loaded", bool)
+            ]
+            for i, team in enumerate(boss_leaderboard_coop):
+                assert len(team.players) <= 3, \
+                    "Assert if BossPlayerTeam has the correct number of players."
+                for attr_name, attr_type in check_instance:
+                    assert isinstance(getattr(team, attr_name), attr_type), \
+                        f"Assert if BossPlayerTeam.{attr_name} is {attr_type}"
+                    for player in team.players:
+                        assert isinstance(player, btd6.BossPlayer), \
+                            "Assert if BossPlayerTeam.players is a tuple of BossPlayer."

--- a/tests/async/test_challenge_browser.py
+++ b/tests/async/test_challenge_browser.py
@@ -1,0 +1,25 @@
+import random
+import aiohttp
+from datetime import datetime
+from bloonspy import AsyncClient, ChallengeFilter
+
+
+class TestChallengeBrowser:
+    async def test_challenge_browser(self) -> None:
+        """
+        Test getting the newest challenges.
+        """
+        async with aiohttp.ClientSession() as session:
+            client = AsyncClient(aiohttp_client=session)
+            challenges = await client.challenges(ChallengeFilter.NEWEST, start_from_page=2, pages=2)
+            assert len(challenges) > 0
+            some_challenge = challenges[random.randint(0, len(challenges)-1)]
+
+            check_instance = [
+                ("name", str), ("created_at", datetime), ("wins", int), ("upvotes", int)
+            ]
+            for attr_name, attr_type in check_instance:
+                assert isinstance(getattr(some_challenge, attr_name), attr_type), \
+                    f"Assert if Challenge.{attr_name} is {attr_type}"
+
+

--- a/tests/async/test_challenge_creator.py
+++ b/tests/async/test_challenge_creator.py
@@ -1,0 +1,26 @@
+import aiohttp
+from bloonspy import AsyncClient
+
+
+class TestChallengeCreator:
+    async def test_challenge(self) -> None:
+        """
+        Test a challenge with a creator.
+        """
+        async with aiohttp.ClientSession() as session:
+            client = AsyncClient(aiohttp_client=session)
+            challenge = await client.get_challenge("ZMDCDTB")
+            creator = await challenge.creator()
+            assert creator.name == "Sarto"
+            assert creator.id == "9cee138c8c94ffac1910864c0b73e577ca554ce8cb18db6c"
+
+    async def test_challenge_no_creator(self) -> None:
+        """
+        Test a challenge with a missing creator.
+        """
+        async with aiohttp.ClientSession() as session:
+            client = AsyncClient(aiohttp_client=session)
+            challenge = await client.get_challenge("rot168220230320")
+            creator = await challenge.creator()
+            assert creator is None
+

--- a/tests/async/test_ct_leaderboard.py
+++ b/tests/async/test_ct_leaderboard.py
@@ -1,0 +1,36 @@
+import random
+
+import aiohttp
+from bloonspy import btd6, AsyncClient
+
+
+class TestCtLeaderboard:
+    async def test_ct_leaderboard(self) -> None:
+        """
+        Test a CT event's leaderboard.
+        """
+        async with aiohttp.ClientSession() as session:
+            client = AsyncClient(aiohttp_client=session)
+            cts = await client.contested_territories()
+            ct_event = cts[1]
+            # Get #51-#100
+            ct_leaderboard_team = await ct_event.leaderboard_team(pages=2, start_from_page=2)
+            ct_leaderboard_player = await ct_event.leaderboard_player(pages=2, start_from_page=2)
+
+            assert len(ct_leaderboard_player) > 0
+            some_player = ct_leaderboard_player[random.randint(0, len(ct_leaderboard_player)-1)]
+            assert isinstance(some_player, btd6.CtPlayer), "Assert if result is CtPlayer"
+
+            check_instance = [("name", str), ("score", int)]
+            for attr_name, attr_type in check_instance:
+                assert isinstance(getattr(some_player, attr_name), attr_type), \
+                    f"Assert if CtPlayer.{attr_name} is {attr_type}"
+
+            assert len(ct_leaderboard_team) > 0
+            some_team = ct_leaderboard_team[random.randint(0, len(ct_leaderboard_team)-1)]
+            assert isinstance(some_team, btd6.CtTeam), "Assert if result is CtTeam"
+
+            check_instance = [("name", str), ("score", int)]
+            for attr_name, attr_type in check_instance:
+                assert isinstance(getattr(some_team, attr_name), attr_type), \
+                    f"Assert if CtTeam.{attr_name} is {attr_type}"

--- a/tests/async/test_ct_leaderboard.py
+++ b/tests/async/test_ct_leaderboard.py
@@ -1,5 +1,5 @@
 import random
-
+from datetime import datetime
 import aiohttp
 from bloonspy import btd6, AsyncClient
 
@@ -34,3 +34,20 @@ class TestCtLeaderboard:
             for attr_name, attr_type in check_instance:
                 assert isinstance(getattr(some_team, attr_name), attr_type), \
                     f"Assert if CtTeam.{attr_name} is {attr_type}"
+
+    async def test_ct(self) -> None:
+        """
+        Test a CT event's data.
+        """
+        async with aiohttp.ClientSession() as session:
+            client = AsyncClient(aiohttp_client=session)
+            cts = await client.contested_territories()
+            ct_event = cts[1]
+
+            check_instance = [
+                ("name", str), ("start", datetime), ("end", datetime), ("id", str), ("total_scores_player", int),
+                ("total_scores_team", int), ("event_number", int)
+            ]
+            for attr_name, attr_type in check_instance:
+                assert isinstance(getattr(ct_event, attr_name), attr_type), \
+                    f"Assert if ContestedTerritoryEvent.{attr_name} is {attr_type}"

--- a/tests/async/test_fetch_odyssey.py
+++ b/tests/async/test_fetch_odyssey.py
@@ -1,0 +1,63 @@
+import aiohttp
+from bloonspy import btd6, AsyncClient
+from bloonspy.exceptions import NotLoaded
+
+
+class TestFetchOdyssey:
+    async def test_odyssey(self) -> None:
+        """
+        Test getting a random odyssey.
+        """
+        async with aiohttp.ClientSession() as cs:
+            client = AsyncClient(aiohttp_client=cs)
+            odysseys = await client.odysseys()
+            some_odyssey = odysseys[0]
+            assert isinstance(some_odyssey, btd6.OdysseyEvent), f"Assert if Client.odysseys returns list[OdysseyEvent]"
+
+            some_other_odyssey = await client.get_odyssey(odysseys[1].id)
+            assert isinstance(some_other_odyssey, btd6.OdysseyEvent), \
+                f"Assert if Client.get_odyssey returns OdysseyEvent"
+
+    async def test_odyssey_challenge(self) -> None:
+        """
+        Test getting an odyssey's islands' challenge data.
+        """
+        async with aiohttp.ClientSession() as cs:
+            client = AsyncClient(aiohttp_client=cs)
+            odysseys = await client.odysseys()
+            some_odyssey = odysseys[0]
+            easy_version = await some_odyssey.easy(eager=True)
+
+            islands = await easy_version.maps()
+            assert isinstance(islands[0], btd6.Challenge), f"Assert if Odyssey.maps returns list[Challenge]"
+
+    async def test_lazy_load_access(self) -> None:
+        """
+        Test lazy loading a resource.
+        """
+        async with aiohttp.ClientSession() as cs:
+            client = AsyncClient(aiohttp_client=cs)
+            odysseys = await client.odysseys()
+            some_odyssey = odysseys[0]
+            easy_version = await some_odyssey.easy()
+
+            try:
+                easy_version.is_extreme
+                assert False, "Did not raise NotLoaded when calling unloaded resource"
+            except NotLoaded:
+                assert True
+
+    async def test_eager_load_access(self) -> None:
+        """
+        Test eager loading a resource.
+        """
+        async with aiohttp.ClientSession() as cs:
+            client = AsyncClient(aiohttp_client=cs)
+            odysseys = await client.odysseys()
+            some_odyssey = odysseys[0]
+            medium_version = await some_odyssey.medium(eager=True)
+            try:
+                medium_version.is_extreme
+            except NotLoaded:
+                assert False, "Raised NotLoaded when calling loaded resource"
+

--- a/tests/async/test_fetch_user.py
+++ b/tests/async/test_fetch_user.py
@@ -1,0 +1,29 @@
+import aiohttp
+from bloonspy import btd6, AsyncClient
+from bloonspy.model import Asset
+
+
+class TestFetchUser:
+    async def test_user(self) -> None:
+        """
+        Test getting an user.
+        """
+        async with aiohttp.ClientSession() as cs:
+            client = AsyncClient(aiohttp_client=cs)
+            user_id = "9cee138c8c94ffac1910864c0b73e577ca554ce8cb18db6c"
+            user = await client.get_user(user_id)
+
+            check_instance = [
+                ("followers", int),
+                ("name", str),
+                ("banner", Asset),
+                ("single_player_medals", btd6.MapMedals),
+                ("boss_normal_medals", btd6.EventMedals),
+                ("ct_local_medals", btd6.CtLocalMedals),
+                ("stats", btd6.GameplayStats),
+            ]
+            for attr_name, attr_type in check_instance:
+                assert isinstance(getattr(user, attr_name), attr_type), \
+                    f"Assert if challenge.{attr_name} is {attr_type}"
+
+

--- a/tests/async/test_race_leaderboard.py
+++ b/tests/async/test_race_leaderboard.py
@@ -1,0 +1,39 @@
+from datetime import datetime
+import aiohttp
+import random
+from bloonspy import btd6, AsyncClient
+
+
+class TestRaceLeaderboard:
+    async def test_race_leaderboard(self) -> None:
+        """
+        Test getting a race event's leaderboard.
+        """
+        async with aiohttp.ClientSession() as cs:
+            client = AsyncClient(aiohttp_client=cs)
+            races = await client.races()
+            race = races[1]
+            # Get #51-#100
+            race_leaderboard = await race.leaderboard(pages=2, start_from_page=2)
+
+            assert len(race_leaderboard) > 0
+            some_player = race_leaderboard[random.randint(0, len(race_leaderboard)-1)]
+            assert isinstance(some_player, btd6.RacePlayer), \
+                "Assert if result is RacePlayer"
+
+            check_instance = [
+                ("name", str), ("score", btd6.Score), ("submission_time", datetime)
+            ]
+            for attr_name, attr_type in check_instance:
+                assert (getattr(some_player, attr_name), attr_type), \
+                    f"Assert if RacePlayer.{attr_name} is {attr_type}"
+
+            some_player = race_leaderboard[random.randint(0, len(race_leaderboard)-1)]
+            await some_player.load_resource()
+            check_instance = [
+                ("name", str), ("score", btd6.Score), ("submission_time", datetime),
+                ("achievements", int), ("boss_normal_medals", btd6.EventMedals)
+            ]
+            for attr_name, attr_type in check_instance:
+                assert (getattr(some_player, attr_name), attr_type), \
+                    f"Assert if RacePlayer.{attr_name} is {attr_type}"

--- a/tests/async/test_team_owner.py
+++ b/tests/async/test_team_owner.py
@@ -1,0 +1,15 @@
+import aiohttp
+from bloonspy import AsyncClient
+
+
+class TestTeamOwner:
+    async def test_team(self) -> None:
+        """
+        Test getting a team's owner.
+        """
+        async with aiohttp.ClientSession() as cs:
+            client = AsyncClient(aiohttp_client=cs)
+            team_id = "9fba1683de92f9f01c4b861d5c70e326ce571db4ca448b30"#"9fbd42d98ac2faa41d40884a5b21b577cb064ebacf168e3f"
+            team = await client.get_team(team_id)
+            owner = await team.owner()
+            assert owner is not None

--- a/tests/async/test_usersave.py
+++ b/tests/async/test_usersave.py
@@ -1,0 +1,36 @@
+import aiohttp
+from bloonspy import AsyncClient
+from bloonspy.exceptions import Forbidden
+from bloonspy import btd6
+
+
+class TestUserSave:
+    async def test_usersave(self) -> None:
+        """
+        Test that an user is loaded correctly.
+        """
+        async with aiohttp.ClientSession() as cs:
+            client = AsyncClient(aiohttp_client=cs)
+            oak = "oak_99b202be126fb7ad580a"
+            user = await client.get_user(oak)
+            user_save = await user.get_progress()
+            assert isinstance(user_save, btd6.UserSave), \
+                "Client.get_user().get_progress() should return UserSave"
+
+    async def test_usersave_not_id(self) -> None:
+        """
+        Test that a Forbidden error will be thrown upon trying to get the save of an User identified by ID, not OAK.
+        """
+        async with aiohttp.ClientSession() as cs:
+            client = AsyncClient(aiohttp_client=cs)
+            uid = "9fbf41dedac0aba64a408f4a5877e577c55618bb9616dc39"
+
+            thrown = False
+            try:
+                user = await client.get_user(uid)
+                await user.get_progress()
+            except Forbidden:
+                thrown = True
+            assert thrown, "Assert that Forbidden is thrown when getting the save data of an User identified by ID"
+
+

--- a/tests/integration/test_fetch_user.py
+++ b/tests/integration/test_fetch_user.py
@@ -3,10 +3,10 @@ from bloonspy import btd6, Client
 from bloonspy.model import Asset
 
 
-class TestFetchTeamOwner(unittest.TestCase):
-    def test_team_owner(self) -> None:
+class TestFetchUser(unittest.TestCase):
+    def test_user(self) -> None:
         """
-        Test getting a team's owner.
+        Test getting an user.
         """
         user_id = "9cee138c8c94ffac1910864c0b73e577ca554ce8cb18db6c"
         user = Client.get_user(user_id)

--- a/tests/integration/test_team_owner.py
+++ b/tests/integration/test_team_owner.py
@@ -11,7 +11,6 @@ class TestTeamOwner(unittest.TestCase):
         team = Client.get_team(team_id)
         owner = team.owner()
         self.assertIsNotNone(owner)
-        self.assertIn(owner.name.lower(), ["zoroark", "thargos", "vaneckpm"])
 
 
 if __name__ == '__main__':

--- a/tests/integration/test_usersave.py
+++ b/tests/integration/test_usersave.py
@@ -9,7 +9,7 @@ class TestUserSave(unittest.TestCase):
         """
         Test that an user is loaded correctly.
         """
-        oak = "oak_8461e54543d73c0b269539ee13b67daa"
+        oak = "oak_99b202be126fb7ad580a"
         user_save = Client.get_user(oak).get_progress()
         self.assertIsInstance(user_save, btd6.UserSave,
                               msg="Client.get_user().get_progress() should return UserSave")


### PR DESCRIPTION
### Fixed
- `ContestedTerritoryEvent` loads correctly from `Client.contested_territories()`

### Removed
- `AsyncClient`'s `aiohttp_client` parameter is mandatory, will no longer create one if not provided. This will be added in a future release, with `async with` support.
